### PR TITLE
Add flags to use pl namespace in Helm instructions

### DIFF
--- a/content/installing-pixie/03-install-schemes/03-helm.md
+++ b/content/installing-pixie/03-install-schemes/03-helm.md
@@ -36,7 +36,7 @@ helm repo add pixie https://pixie-helm-charts.storage.googleapis.com
 helm repo update
 
 # install the Pixie chart
-helm install pixie pixie/pixie-chart --set deployKey=<deploy-key-goes-here> --namespace pl --create-namespace
+helm install pixie pixie/pixie-chart --set deployKey=<deploy-key-goes-here> --namespace <desired-namespace> --create-namespace
 ```
 
 ## 4. Verify

--- a/content/installing-pixie/03-install-schemes/03-helm.md
+++ b/content/installing-pixie/03-install-schemes/03-helm.md
@@ -36,7 +36,7 @@ helm repo add pixie https://pixie-helm-charts.storage.googleapis.com
 helm repo update
 
 # install the Pixie chart
-helm install pixie pixie/pixie-chart --set deployKey=<deploy-key-goes-here>
+helm install pixie pixie/pixie-chart --set deployKey=<deploy-key-goes-here> --namespace pl --create-namespace
 ```
 
 ## 4. Verify


### PR DESCRIPTION
Currently working to finalize non-pl namespace support for Helm, but in the meantime, here are the flags to use the pl namespace for Helm.