### PR TITLE
Only read .env when not running on netlify

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -16,8 +16,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-require('dotenv')
-  .config();
+if (!process.env.NETLIFY) {
+  require('dotenv')
+    .config();
+}
+
 const containers = require('remark-containers');
 const config = require('./config');
 


### PR DESCRIPTION
This should fix the search box in netlify so because I think dotenv was overriding the variables. 