### PR TITLE
fix image ref

### DIFF
--- a/src/components/image-zoom-modal.plugin.ts
+++ b/src/components/image-zoom-modal.plugin.ts
@@ -96,7 +96,7 @@ export function runZoom() {
   children.forEach(
     (e) => {
       e.onclick = (event) => {
-        const picture = document.getElementsByClassName('doc-image')[0];
+        const picture = e.getElementsByClassName('doc-image')[0];
         modalImg.innerHTML = picture.outerHTML;
         isModalVisible = true;
         modal.classList.add('show');


### PR DESCRIPTION
Fixes a bug on docs.px.dev where clicking an image to open the popup modal always opens the 1st image on the page. 