### PR TITLE
Replace Learn More button on Docs front page with Install Guide button

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -417,9 +417,9 @@ const IndexPage = withStyles((theme: Theme) => ({
                   variant='outlined'
                   color='secondary'
                   size='large'
-                  onClick={scrollToScripts}
+                  href='/installing-pixie'
                 >
-                  Learn More
+                  Install Guide
                 </MainButton>
               </ButtonsBar>
             </Grid>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -351,11 +351,6 @@ const IndexPage = withStyles((theme: Theme) => ({
     setOpenVideo(false);
   };
 
-  const scrollToScripts = () => {
-    document.getElementById('scripts-section')
-      .scrollIntoView({ block: 'start', behavior: 'smooth' });
-  };
-
   return (
     <Layout location={location}>
       <SEO


### PR DESCRIPTION
In the current version of the docs, the Learn More button scrolls down to the Use cases section.

The user has chosen to enter the docs so I think we should put a more relevant button, since the side panel / docs are hard to discover.

We will update this page soon but this seems like a quick & easy ROI to make installation guide more discoverable.

![image](https://user-images.githubusercontent.com/5460125/125567563-2effae86-303d-4d13-bd98-c3be1a0f7f43.png)
