### PR TITLE
Bump up k8s version requirement

### DIFF
--- a/content/en/02-installing-pixie/01-requirements.md
+++ b/content/en/02-installing-pixie/01-requirements.md
@@ -11,7 +11,7 @@ Please refer to the [install guides](/installing-pixie/install-guides/) for info
 
 ## Kubernetes
 
-Kubernetes `v1.12+` is required.
+Kubernetes `v1.16+` is required.
 
 ### Production Environments
 


### PR DESCRIPTION
Our updates for `v1.22` compatibility cause us to be incompatible with anything below `v1.16`

Signed-off-by: Vihang Mehta <vihang@pixielabs.ai>