### PR TITLE
Update minikube and community pixie

### DIFF
--- a/content/en/02-installing-pixie/02-setting-up-k8s/01-minikube-setup.md
+++ b/content/en/02-installing-pixie/02-setting-up-k8s/01-minikube-setup.md
@@ -38,7 +38,7 @@ To deploy a specific K8s version [supported by Pixie](/installing-pixie/requirem
 
 ## Verify
 
-Run `minikube dashboard` or `kubectl get nodes` to verify your cluster is up and running.
+Run `kubectl get nodes` to verify your cluster is up and running. Run 'kubectl config current-context` to verify that K8s is pointing to your cluster. 
 
 ## Deploy Pixie
 

--- a/content/en/02-installing-pixie/02-setting-up-k8s/01-minikube-setup.md
+++ b/content/en/02-installing-pixie/02-setting-up-k8s/01-minikube-setup.md
@@ -38,7 +38,7 @@ To deploy a specific K8s version [supported by Pixie](/installing-pixie/requirem
 
 ## Verify
 
-Run `kubectl get nodes` to verify your cluster is up and running. Run 'kubectl config current-context` to verify that `kubectl` is pointing to your cluster. 
+Run `kubectl get nodes` to verify your cluster is up and running. Run `kubectl config current-context` to verify that `kubectl` is pointing to your cluster. 
 
 ## Deploy Pixie
 

--- a/content/en/02-installing-pixie/02-setting-up-k8s/01-minikube-setup.md
+++ b/content/en/02-installing-pixie/02-setting-up-k8s/01-minikube-setup.md
@@ -38,7 +38,7 @@ To deploy a specific K8s version [supported by Pixie](/installing-pixie/requirem
 
 ## Verify
 
-Run `kubectl get nodes` to verify your cluster is up and running. Run 'kubectl config current-context` to verify that K8s is pointing to your cluster. 
+Run `kubectl get nodes` to verify your cluster is up and running. Run 'kubectl config current-context` to verify that `kubectl` is pointing to your cluster. 
 
 ## Deploy Pixie
 

--- a/content/en/02-installing-pixie/03-install-guides/01-community-cloud-for-pixie.md
+++ b/content/en/02-installing-pixie/03-install-guides/01-community-cloud-for-pixie.md
@@ -76,13 +76,6 @@ px-operator         vizier-operator
 
 To deploy Pixie to another cluster, change your `kubectl config current-context` to point to that cluster. Then repeat the same deploy commands shown in this step.
 
-If the `px deploy` does not successfully complete you might retry it after deleting all the nodes and the namespace as sometimes the deploy nodes can get into a bad state:
-
-```bash
-px delete
-kubectl delete namespace px-operator
-```
-
 ## 5. Use Pixie
 
 ### Deploy a demo microservices app (optional)

--- a/content/en/02-installing-pixie/03-install-guides/01-community-cloud-for-pixie.md
+++ b/content/en/02-installing-pixie/03-install-guides/01-community-cloud-for-pixie.md
@@ -76,6 +76,13 @@ px-operator         vizier-operator
 
 To deploy Pixie to another cluster, change your `kubectl config current-context` to point to that cluster. Then repeat the same deploy commands shown in this step.
 
+If the `px deploy` does not successfully complete you might retry it after deleting all the nodes and the namespace as sometimes the deploy nodes can get into a bad state:
+
+```bash
+px delete
+kubectl delete namespace px-operator
+```
+
 ## 5. Use Pixie
 
 ### Deploy a demo microservices app (optional)


### PR DESCRIPTION
Make some changes to remove friction points during setup. I encountered these while getting set up for development, but they could help all users. 

- In the minikube setup doc, update the `Verify` section. Delete the `minikube dashboard` command because that doesn't seem to provide info. Keep `kubectl get nodes`. Add `kubectl config current-context` to verify that k8 is pointing to the correct cluster.
- In the pixie community install doc, add a section for deleting pixie and the namespace in case of a failed `px deploy`. 