### PR TITLE
Issue #98: Update GKE setup instructions to ensure node resources meet requirements

### DIFF
--- a/content/en/02-installing-pixie/02-setting-up-k8s/03-gke-setup.md
+++ b/content/en/02-installing-pixie/02-setting-up-k8s/03-gke-setup.md
@@ -39,10 +39,10 @@ gcloud config set compute/zone compute-zone
 
 ### Create the cluster
 
-Run the following command to create a 2 node cluster (each node with 2 vCPUs and 12GB of RAM):
+Run the following command to create a 2 node cluster:
 
 ```
-gcloud container clusters create cluster-name --num-nodes=2 --machine-type=custom-2-12288
+gcloud container clusters create cluster-name --num-nodes=2 --machine-type=e2-standard-2
 ```
 
 Please review, GCP's [docs](https://cloud.google.com/kubernetes-engine/docs/concepts/cluster-architecture) for more deployment details and insructions.

--- a/content/en/02-installing-pixie/02-setting-up-k8s/03-gke-setup.md
+++ b/content/en/02-installing-pixie/02-setting-up-k8s/03-gke-setup.md
@@ -39,10 +39,10 @@ gcloud config set compute/zone compute-zone
 
 ### Create the cluster
 
-Run the following command to create a 2 node cluster:
+Run the following command to create a 2 node cluster (each node with 2 vCPUs and 12GB of RAM):
 
 ```
-gcloud container clusters create cluster-name --num-nodes=2
+gcloud container clusters create cluster-name --num-nodes=2 --machine-type=custom-2-12288
 ```
 
 Please review, GCP's [docs](https://cloud.google.com/kubernetes-engine/docs/concepts/cluster-architecture) for more deployment details and insructions.


### PR DESCRIPTION
@antonmry filed an issue that the default GKE install we suggest doesn't provision enough resources: https://github.com/pixie-io/docs.px.dev/issues/98 

I bumped the example to use a `custom-2-12288` machine type, which worked when I tested a Pixie deploy with px-sock-shop on a new GKE cluster with those resources.