### PR TITLE
#107: Add note that the installation of cloud deps may need to be re-run

### DIFF
--- a/content/en/02-installing-pixie/03-install-guides/02-self-hosted-pixie.md
+++ b/content/en/02-installing-pixie/03-install-guides/02-self-hosted-pixie.md
@@ -56,7 +56,7 @@ kubectl create namespace plc
 
 6. Install `kustomize` following the directions [here](https://kubectl.docs.kubernetes.io/installation/kustomize/).
 
-7. Deploy Pixie Cloud dependencies and wait for all pods within the `plc` namespace to become ready and available before proceeding to the next step.
+7. Deploy Pixie Cloud dependencies and wait for all pods within the `plc` namespace to become ready and available before proceeding to the next step. If there is an error, you may need to retry this step.
 
 ```bash
 kustomize build k8s/cloud_deps/public/ | kubectl apply -f - --namespace=plc


### PR DESCRIPTION
Sometimes, for reasons outside of our control, the Custom Resources don't get created in time when the YAML is applied. In this scenario, the user should just rerun the command if they see an error.