### PR TITLE
Add list of px binaries.

### DIFF
--- a/content/en/02-installing-pixie/04-install-schemes/01-cli.md
+++ b/content/en/02-installing-pixie/04-install-schemes/01-cli.md
@@ -26,17 +26,17 @@ bash -c "$(curl -fsSL https://withpixie.ai/install.sh)"
 
 ### Directly downloading the binary
 
-- [https://storage.googleapis.com/pixie-prod-artifacts/cli/latest/cli_darwin_amd64](https://storage.googleapis.com/pixie-prod-artifacts/cli/latest/cli_darwin_amd64)
-- [https://storage.googleapis.com/pixie-prod-artifacts/cli/latest/cli_darwin_amd64.sha256](https://storage.googleapis.com/pixie-prod-artifacts/cli/latest/cli_darwin_amd64.sha256)
-- [https://storage.googleapis.com/pixie-prod-artifacts/cli/latest/cli_linux_amd64](https://storage.googleapis.com/pixie-prod-artifacts/cli/latest/cli_linux_amd64)
-- [https://storage.googleapis.com/pixie-prod-artifacts/cli/latest/cli_linux_amd64.sha256](https://storage.googleapis.com/pixie-prod-artifacts/cli/latest/cli_linux_amd64.sha256)
+- [https://storage.googleapis.com/pixie-dev-public/cli/latest/cli_darwin_universal](https://storage.googleapis.com/pixie-dev-public/cli/latest/cli_darwin_universal)
+- [https://storage.googleapis.com/pixie-dev-public/cli/latest/cli_darwin_universal.sha256](https://storage.googleapis.com/pixie-dev-public/cli/latest/cli_darwin_universal.sha256)
+- [https://storage.googleapis.com/pixie-dev-public/cli/latest/cli_linux_amd64](https://storage.googleapis.com/pixie-dev-public/cli/latest/cli_linux_amd64)
+- [https://storage.googleapis.com/pixie-dev-public/cli/latest/cli_linux_amd64.sha256](https://storage.googleapis.com/pixie-dev-public/cli/latest/cli_linux_amd64.sha256)
 
 ``` bash
 # Download the latest Pixie linux binary.
-curl -o px https://storage.googleapis.com/pixie-prod-artifacts/cli/latest/cli_linux_amd64
+curl -o px https://storage.googleapis.com/pixie-dev-public/cli/latest/cli_linux_amd64
 
 # (Optional) Check the signature matches.
-curl -o px_checksum https://storage.googleapis.com/pixie-prod-artifacts/cli/latest/cli_linux_amd64.sha256
+curl -o px_checksum https://storage.googleapis.com/pixie-dev-public/cli/latest/cli_linux_amd64.sha256
 cat px_checksum
 sha256sum px
 
@@ -55,8 +55,8 @@ alias px="docker run -i --rm -v ${HOME}/.pixie:/root/.pixie pixielabs/px"
 
 ### Using Debian package
 
-- [https://storage.googleapis.com/pixie-prod-artifacts/cli/latest/pixie-px.x86_64.deb](https://storage.googleapis.com/pixie-prod-artifacts/cli/latest/pixie-px.x86_64.deb)
-- [https://storage.googleapis.com/pixie-prod-artifacts/cli/latest/pixie-px.x86_64.deb.sha256](https://storage.googleapis.com/pixie-prod-artifacts/cli/latest/pixie-px.x86_64.deb.sha256)
+- [https://storage.googleapis.com/pixie-dev-public/cli/latest/pixie-px.x86_64.deb](https://storage.googleapis.com/pixie-dev-public/cli/latest/pixie-px.x86_64.deb)
+- [https://storage.googleapis.com/pixie-dev-public/cli/latest/pixie-px.x86_64.deb.sha256](https://storage.googleapis.com/pixie-dev-public/cli/latest/pixie-px.x86_64.deb.sha256)
 
 ``` bash
 # Install Pixie .deb package.
@@ -65,8 +65,8 @@ dpkg -i pixie-px.x86_64.deb
 
 ### Using RPM
 
-- [https://storage.googleapis.com/pixie-prod-artifacts/cli/latest/pixie-px.x86_64.rpm](https://storage.googleapis.com/pixie-prod-artifacts/cli/latest/pixie-px.x86_64.rpm)
-- [https://storage.googleapis.com/pixie-prod-artifacts/cli/latest/pixie-px.x86_64.rpm.sha256](https://storage.googleapis.com/pixie-prod-artifacts/cli/latest/pixie-px.x86_64.rpm.sha256)
+- [https://storage.googleapis.com/pixie-dev-public/cli/latest/pixie-px.x86_64.rpm](https://storage.googleapis.com/pixie-dev-public/cli/latest/pixie-px.x86_64.rpm)
+- [https://storage.googleapis.com/pixie-dev-public/cli/latest/pixie-px.x86_64.rpm.sha256](https://storage.googleapis.com/pixie-dev-public/cli/latest/pixie-px.x86_64.rpm.sha256)
 
 ``` bash
 # Install Pixie .rpm package.

--- a/content/en/02-installing-pixie/04-install-schemes/01-cli.md
+++ b/content/en/02-installing-pixie/04-install-schemes/01-cli.md
@@ -26,11 +26,18 @@ bash -c "$(curl -fsSL https://withpixie.ai/install.sh)"
 
 ### Directly downloading the binary
 
-``` bash
-# Download the latest Pixie binary.
-curl -o px https://storage.googleapis.com/pixie-prod-artifacts/cli/latest/cli_darwin_amd64
+- [https://storage.googleapis.com/pixie-prod-artifacts/cli/latest/cli_darwin_amd64](https://storage.googleapis.com/pixie-prod-artifacts/cli/latest/cli_darwin_amd64)
+- [https://storage.googleapis.com/pixie-prod-artifacts/cli/latest/cli_darwin_amd64.sha256](https://storage.googleapis.com/pixie-prod-artifacts/cli/latest/cli_darwin_amd64.sha256)
+- [https://storage.googleapis.com/pixie-prod-artifacts/cli/latest/cli_linux_amd64](https://storage.googleapis.com/pixie-prod-artifacts/cli/latest/cli_linux_amd64)
+- [https://storage.googleapis.com/pixie-prod-artifacts/cli/latest/cli_linux_amd64.sha256](https://storage.googleapis.com/pixie-prod-artifacts/cli/latest/cli_linux_amd64.sha256)
 
-# Check the signature matches.
+``` bash
+# Download the latest Pixie linux binary.
+curl -o px https://storage.googleapis.com/pixie-prod-artifacts/cli/latest/cli_linux_amd64
+
+# (Optional) Check the signature matches.
+curl -o px_checksum https://storage.googleapis.com/pixie-prod-artifacts/cli/latest/cli_linux_amd64.sha256
+cat px_checksum
 sha256sum px
 
 # Make it executable.

--- a/content/en/02-installing-pixie/04-install-schemes/01-cli.md
+++ b/content/en/02-installing-pixie/04-install-schemes/01-cli.md
@@ -26,10 +26,14 @@ bash -c "$(curl -fsSL https://withpixie.ai/install.sh)"
 
 ### Directly downloading the binary
 
-- [https://storage.googleapis.com/pixie-dev-public/cli/latest/cli_darwin_universal](https://storage.googleapis.com/pixie-dev-public/cli/latest/cli_darwin_universal)
-- [https://storage.googleapis.com/pixie-dev-public/cli/latest/cli_darwin_universal.sha256](https://storage.googleapis.com/pixie-dev-public/cli/latest/cli_darwin_universal.sha256)
-- [https://storage.googleapis.com/pixie-dev-public/cli/latest/cli_linux_amd64](https://storage.googleapis.com/pixie-dev-public/cli/latest/cli_linux_amd64)
-- [https://storage.googleapis.com/pixie-dev-public/cli/latest/cli_linux_amd64.sha256](https://storage.googleapis.com/pixie-dev-public/cli/latest/cli_linux_amd64.sha256)
+#### Assets
+
+- [cli_darwin_universal](https://storage.googleapis.com/pixie-dev-public/cli/latest/cli_darwin_universal)
+- [cli_darwin_universal.sha256](https://storage.googleapis.com/pixie-dev-public/cli/latest/cli_darwin_universal.sha256)
+- [cli_linux_amd64](https://storage.googleapis.com/pixie-dev-public/cli/latest/cli_linux_amd64)
+- [cli_linux_amd64.sha256](https://storage.googleapis.com/pixie-dev-public/cli/latest/cli_linux_amd64.sha256)
+
+Download the correct binary for your operating system and make it executable:
 
 ``` bash
 # Download the latest Pixie linux binary.
@@ -55,8 +59,12 @@ alias px="docker run -i --rm -v ${HOME}/.pixie:/root/.pixie pixielabs/px"
 
 ### Using Debian package
 
-- [https://storage.googleapis.com/pixie-dev-public/cli/latest/pixie-px.x86_64.deb](https://storage.googleapis.com/pixie-dev-public/cli/latest/pixie-px.x86_64.deb)
-- [https://storage.googleapis.com/pixie-dev-public/cli/latest/pixie-px.x86_64.deb.sha256](https://storage.googleapis.com/pixie-dev-public/cli/latest/pixie-px.x86_64.deb.sha256)
+Download the assets:
+
+- [pixie-px.x86_64.deb](https://storage.googleapis.com/pixie-dev-public/cli/latest/pixie-px.x86_64.deb)
+- [pixie-px.x86_64.deb.sha256](https://storage.googleapis.com/pixie-dev-public/cli/latest/pixie-px.x86_64.deb.sha256)
+
+Install the Pixie package:
 
 ``` bash
 # Install Pixie .deb package.
@@ -65,8 +73,12 @@ dpkg -i pixie-px.x86_64.deb
 
 ### Using RPM
 
-- [https://storage.googleapis.com/pixie-dev-public/cli/latest/pixie-px.x86_64.rpm](https://storage.googleapis.com/pixie-dev-public/cli/latest/pixie-px.x86_64.rpm)
-- [https://storage.googleapis.com/pixie-dev-public/cli/latest/pixie-px.x86_64.rpm.sha256](https://storage.googleapis.com/pixie-dev-public/cli/latest/pixie-px.x86_64.rpm.sha256)
+Download the assets:
+
+- [pixie-px.x86_64.rpm](https://storage.googleapis.com/pixie-dev-public/cli/latest/pixie-px.x86_64.rpm)
+- [pixie-px.x86_64.rpm.sha256](https://storage.googleapis.com/pixie-dev-public/cli/latest/pixie-px.x86_64.rpm.sha256)
+
+Install the Pixie package:
 
 ``` bash
 # Install Pixie .rpm package.


### PR DESCRIPTION
The CLI install directions were missing the list of available binaries. Reported in https://github.com/pixie-io/docs.px.dev/issues/132.

Signed-off-by: Hannah Troisi <htroisi@pixielabs.ai>