### PR TITLE
Fix lint error from bad string

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -173,8 +173,7 @@ exports.createPages = ({
             jsonDocumentation.dataframeOpDocs,
             'operators',
             'DataFrame',
-
-            `The methods you can apply to DataFrames`,
+            'The methods you can apply to DataFrames',
           );
 
           // create udfDocs index Pages


### PR DESCRIPTION
Lint error was preventing the netlify builder from running. This fixes the error.
Signed-off-by: Phillip Kuznetsov <pkuznetsov@pixielabs.ai>