### PR TITLE
Fix python API doc format

### DIFF
--- a/external/pxl_documentation.json
+++ b/external/pxl_documentation.json
@@ -2,70 +2,6 @@
   "compileFnDocs": [
     {
       "body": {
-        "name": "px.minutes",
-        "brief": "Gets the specified number of minutes.",
-        "examples": [
-          {
-            "value": "```\n# Returns 2 minutes.\ntime = px.minutes(2)\n```"
-          }
-        ]
-      },
-      "funcDoc": {
-        "args": [
-          {
-            "ident": "unit",
-            "desc": "The number of minutes to render.",
-            "types": [
-              "int"
-            ]
-          }
-        ],
-        "returnType": {
-          "desc": "Duration representing `unit` minutes.",
-          "types": [
-            "px.Duration"
-          ]
-        }
-      }
-    },
-    {
-      "body": {
-        "name": "px.strptime",
-        "brief": "Parse a datestring into a px.Time.",
-        "desc": "Parse a datestring using a standard time format template into an internal time representation. The format must follow the C strptime format, outlined in this document: https://pubs.opengroup.org/onlinepubs/009695399/functions/strptime.html   ",
-        "examples": [
-          {
-            "value": "```\ntime = px.strptime(\"2020-03-12 19:39:59 -0200\", \"%Y-%m-%d %H:%M:%S %z\")\n```"
-          }
-        ]
-      },
-      "funcDoc": {
-        "args": [
-          {
-            "ident": "date_string",
-            "desc": "The time as a string, should match the format object.",
-            "types": [
-              "string"
-            ]
-          },
-          {
-            "ident": "format",
-            "desc": "The string format according to the C strptime format https://pubs.opengroup.org/onlinepubs/009695399/functions/strptime.html",
-            "types": [
-              "string"
-            ]
-          }
-        ],
-        "returnType": {
-          "desc": "The time value represented in the data.",
-          "types": [
-            "px.Time"
-          ]
-        }
-      }
-    },
-    {
-      "body": {
         "name": "px.equals_any",
         "brief": "Returns true if the value is in the list.",
         "desc": "Check equality of the input value with every element of a list.   ",
@@ -96,136 +32,6 @@
           "desc": "An expression that evaluates to true if the value is found in the list.",
           "types": [
             "px.Expr"
-          ]
-        }
-      }
-    },
-    {
-      "body": {
-        "name": "px.uint128",
-        "brief": "Parse the UUID string into a UInt128.",
-        "desc": "Parse the UUID string of canonical textual representation into a 128bit integer (ie \"123e4567-e89b-12d3-a456-426614174000\"). Errors out if the string is not the correct format.   ",
-        "examples": [
-          {
-            "value": "```\nval = px.uint128(\"123e4567-e89b-12d3-a456-426614174000\")\n```"
-          }
-        ]
-      },
-      "funcDoc": {
-        "args": [
-          {
-            "ident": "uuid",
-            "desc": "the uuid in canoncial uuid4 format (\"123e4567-e89b-12d3-a456-426614174000\")",
-            "types": [
-              "string"
-            ]
-          }
-        ],
-        "returnType": {
-          "desc": "The uuid as a uint128.",
-          "types": [
-            "uint128"
-          ]
-        }
-      }
-    },
-    {
-      "body": {
-        "name": "px.now",
-        "brief": "Get the current time.",
-        "examples": []
-      },
-      "funcDoc": {
-        "args": [],
-        "returnType": {
-          "desc": "The current time as defined at the start of compilation.",
-          "types": [
-            "px.Time"
-          ]
-        }
-      }
-    },
-    {
-      "body": {
-        "name": "px.seconds",
-        "brief": "Gets the specified number of seconds.",
-        "examples": [
-          {
-            "value": "```\n# Returns 2 seconds.\ntime = px.seconds(2)\n```"
-          }
-        ]
-      },
-      "funcDoc": {
-        "args": [
-          {
-            "ident": "unit",
-            "desc": "The number of seconds to render.",
-            "types": [
-              "int"
-            ]
-          }
-        ],
-        "returnType": {
-          "desc": "Duration representing `unit` seconds.",
-          "types": [
-            "px.Duration"
-          ]
-        }
-      }
-    },
-    {
-      "body": {
-        "name": "px.microseconds",
-        "brief": "Gets the specified number of microseconds.",
-        "examples": [
-          {
-            "value": "```\n# Returns 2 microseconds.\ntime = px.microseconds(2)\n```"
-          }
-        ]
-      },
-      "funcDoc": {
-        "args": [
-          {
-            "ident": "unit",
-            "desc": "The number of microseconds to render.",
-            "types": [
-              "int"
-            ]
-          }
-        ],
-        "returnType": {
-          "desc": "Duration representing `unit` microseconds.",
-          "types": [
-            "px.Duration"
-          ]
-        }
-      }
-    },
-    {
-      "body": {
-        "name": "px.parse_duration",
-        "brief": "Parse a duration string to a duration in nanoseconds.",
-        "desc": "Parse a duration string (\"-5m\") to integer nanoseconds (-3,000,000,000) while preserving the sign from the string.   ",
-        "examples": [
-          {
-            "value": "```\n# duration = -300000000000\nduration = px.parse_duration(\"-5m\")\n# duration = 300000000000\nduration = px.parse_duration(\"5m\")\n```"
-          }
-        ]
-      },
-      "funcDoc": {
-        "args": [
-          {
-            "ident": "duration",
-            "desc": "The duration in string form.",
-            "types": [
-              "string"
-            ]
-          }
-        ],
-        "returnType": {
-          "desc": "The duration in nanoseconds.",
-          "types": [
-            "px.Duration"
           ]
         }
       }
@@ -303,6 +109,143 @@
     },
     {
       "body": {
+        "name": "px.milliseconds",
+        "brief": "Gets the specified number of milliseconds.",
+        "examples": [
+          {
+            "value": "```\n# Returns 2 milliseconds.\ntime = px.milliseconds(2)\n```"
+          }
+        ]
+      },
+      "funcDoc": {
+        "args": [
+          {
+            "ident": "unit",
+            "desc": "The number of milliseconds to render.",
+            "types": [
+              "int"
+            ]
+          }
+        ],
+        "returnType": {
+          "desc": "Duration representing `unit` milliseconds.",
+          "types": [
+            "px.Duration"
+          ]
+        }
+      }
+    },
+    {
+      "body": {
+        "name": "px.strptime",
+        "brief": "Parse a datestring into a px.Time.",
+        "desc": "Parse a datestring using a standard time format template into an internal time representation. The format must follow the C strptime format, outlined in this document: https://pubs.opengroup.org/onlinepubs/009695399/functions/strptime.html   ",
+        "examples": [
+          {
+            "value": "```\ntime = px.strptime(\"2020-03-12 19:39:59 -0200\", \"%Y-%m-%d %H:%M:%S %z\")\n```"
+          }
+        ]
+      },
+      "funcDoc": {
+        "args": [
+          {
+            "ident": "date_string",
+            "desc": "The time as a string, should match the format object.",
+            "types": [
+              "string"
+            ]
+          },
+          {
+            "ident": "format",
+            "desc": "The string format according to the C strptime format https://pubs.opengroup.org/onlinepubs/009695399/functions/strptime.html",
+            "types": [
+              "string"
+            ]
+          }
+        ],
+        "returnType": {
+          "desc": "The time value represented in the data.",
+          "types": [
+            "px.Time"
+          ]
+        }
+      }
+    },
+    {
+      "body": {
+        "name": "px.microseconds",
+        "brief": "Gets the specified number of microseconds.",
+        "examples": [
+          {
+            "value": "```\n# Returns 2 microseconds.\ntime = px.microseconds(2)\n```"
+          }
+        ]
+      },
+      "funcDoc": {
+        "args": [
+          {
+            "ident": "unit",
+            "desc": "The number of microseconds to render.",
+            "types": [
+              "int"
+            ]
+          }
+        ],
+        "returnType": {
+          "desc": "Duration representing `unit` microseconds.",
+          "types": [
+            "px.Duration"
+          ]
+        }
+      }
+    },
+    {
+      "body": {
+        "name": "px.now",
+        "brief": "Get the current time.",
+        "examples": []
+      },
+      "funcDoc": {
+        "args": [],
+        "returnType": {
+          "desc": "The current time as defined at the start of compilation.",
+          "types": [
+            "px.Time"
+          ]
+        }
+      }
+    },
+    {
+      "body": {
+        "name": "px.parse_duration",
+        "brief": "Parse a duration string to a duration in nanoseconds.",
+        "desc": "Parse a duration string (\"-5m\") to integer nanoseconds (-3,000,000,000) while preserving the sign from the string.   ",
+        "examples": [
+          {
+            "value": "```\n# duration = -300000000000\nduration = px.parse_duration(\"-5m\")\n# duration = 300000000000\nduration = px.parse_duration(\"5m\")\n```"
+          }
+        ]
+      },
+      "funcDoc": {
+        "args": [
+          {
+            "ident": "duration",
+            "desc": "The duration in string form.",
+            "types": [
+              "string"
+            ]
+          }
+        ],
+        "returnType": {
+          "desc": "The duration in nanoseconds.",
+          "types": [
+            "px.Duration"
+          ]
+        }
+      }
+    },
+    {
+      "body": {
         "name": "px.days",
         "brief": "Gets the specified number of days.",
         "examples": [
@@ -331,11 +274,11 @@
     },
     {
       "body": {
-        "name": "px.milliseconds",
-        "brief": "Gets the specified number of milliseconds.",
+        "name": "px.seconds",
+        "brief": "Gets the specified number of seconds.",
         "examples": [
           {
-            "value": "```\n# Returns 2 milliseconds.\ntime = px.milliseconds(2)\n```"
+            "value": "```\n# Returns 2 seconds.\ntime = px.seconds(2)\n```"
           }
         ]
       },
@@ -343,14 +286,71 @@
         "args": [
           {
             "ident": "unit",
-            "desc": "The number of milliseconds to render.",
+            "desc": "The number of seconds to render.",
             "types": [
               "int"
             ]
           }
         ],
         "returnType": {
-          "desc": "Duration representing `unit` milliseconds.",
+          "desc": "Duration representing `unit` seconds.",
+          "types": [
+            "px.Duration"
+          ]
+        }
+      }
+    },
+    {
+      "body": {
+        "name": "px.uint128",
+        "brief": "Parse the UUID string into a UInt128.",
+        "desc": "Parse the UUID string of canonical textual representation into a 128bit integer (ie \"123e4567-e89b-12d3-a456-426614174000\"). Errors out if the string is not the correct format.   ",
+        "examples": [
+          {
+            "value": "```\nval = px.uint128(\"123e4567-e89b-12d3-a456-426614174000\")\n```"
+          }
+        ]
+      },
+      "funcDoc": {
+        "args": [
+          {
+            "ident": "uuid",
+            "desc": "the uuid in canoncial uuid4 format (\"123e4567-e89b-12d3-a456-426614174000\")",
+            "types": [
+              "string"
+            ]
+          }
+        ],
+        "returnType": {
+          "desc": "The uuid as a uint128.",
+          "types": [
+            "uint128"
+          ]
+        }
+      }
+    },
+    {
+      "body": {
+        "name": "px.minutes",
+        "brief": "Gets the specified number of minutes.",
+        "examples": [
+          {
+            "value": "```\n# Returns 2 minutes.\ntime = px.minutes(2)\n```"
+          }
+        ]
+      },
+      "funcDoc": {
+        "args": [
+          {
+            "ident": "unit",
+            "desc": "The number of minutes to render.",
+            "types": [
+              "int"
+            ]
+          }
+        ],
+        "returnType": {
+          "desc": "Duration representing `unit` minutes.",
           "types": [
             "px.Duration"
           ]
@@ -359,64 +359,6 @@
     }
   ],
   "dataframeOpDocs": [
-    {
-      "body": {
-        "name": "DataFrame.filter",
-        "brief": "Returns a DataFrame with only those rows that match the condition.",
-        "desc": "Filters for the rows in the DataFrame that match the boolean condition. Will error out if you don't pass in a boolean expression. The functions available are defined in [UDFs](/reference/pxl/udf).     ",
-        "examples": [
-          {
-            "value": "```\ndf = px.DataFrame('http_events')\n# Filter for only http requests that are greater than 100 milliseconds\ndf = df[df['resp_latency_ns'] \u003e 100 * 1000 * 1000]\n```"
-          }
-        ]
-      },
-      "funcDoc": {
-        "args": [
-          {
-            "ident": "key",
-            "desc": "DataFrame expression that evaluates to a bool. Filter keeps any row that causes the expression to evaluate to True.",
-            "types": [
-              "ScalarExpression"
-            ]
-          }
-        ],
-        "returnType": {
-          "desc": "DataFrame with only those rows that return True for the expression.",
-          "types": [
-            "px.DataFrame"
-          ]
-        }
-      }
-    },
-    {
-      "body": {
-        "name": "DataFrame.groupby",
-        "brief": "Groups the data in preparation for an aggregate.",
-        "desc": "Groups the data by the unique values in the passed in columns. At the current time we do not support standalone groupings, you must always follow the groupby() call with a call to `agg()`.     ",
-        "examples": [
-          {
-            "value": "```\n# Group by UPID and calculate maximum user time for the each\n# UPID group.\ndf = px.DataFrame('process_stats')\ndf = df.groupby('upid').agg(cpu_utime=('cpu_utime_ns', px.max))\n```"
-          }
-        ]
-      },
-      "funcDoc": {
-        "args": [
-          {
-            "ident": "columns",
-            "desc": "DataFrame columns to group by, either as a string or a list.",
-            "types": [
-              "Union[str,List[str]]"
-            ]
-          }
-        ],
-        "returnType": {
-          "desc": "Grouped DataFrame. Must be followed by a call to `agg()`.",
-          "types": [
-            "px.DataFrame"
-          ]
-        }
-      }
-    },
     {
       "body": {
         "name": "DataFrame.append",
@@ -483,98 +425,6 @@
     },
     {
       "body": {
-        "name": "DataFrame.rolling",
-        "brief": "Groups the data by rolling windows.",
-        "desc": "Rolls up data into groups based on the rolling window that it belongs to. Used to define window aggregates, the streaming analog of batch aggregates.      ",
-        "examples": [
-          {
-            "value": "```\ndf = px.DataFrame('process_stats')\ndf = df.rolling('2s').agg(...)\n```"
-          }
-        ]
-      },
-      "funcDoc": {
-        "args": [
-          {
-            "ident": "window",
-            "desc": "the size of the rolling window.",
-            "types": [
-              "px.Duration"
-            ]
-          }
-        ],
-        "returnType": {
-          "desc": "DataFrame grouped into rolling windows. Must apply either a groupby or an aggregate on the returned DataFrame.",
-          "types": [
-            "px.DataFrame"
-          ]
-        }
-      }
-    },
-    {
-      "body": {
-        "name": "DataFrame.stream",
-        "brief": "Execute this DataFrame in streaming mode.",
-        "desc": "Returns the input DataFrame, but set to streaming mode. Streaming queries execute indefinitely, as opposed to batch queries which return a finite result.     ",
-        "examples": [
-          {
-            "value": "```\ndf = px.DataFrame('http_events').stream()\n```"
-          }
-        ]
-      },
-      "funcDoc": {
-        "args": [],
-        "returnType": {
-          "desc": "the parent DataFrame in streaming mode.",
-          "types": [
-            "px.DataFrame"
-          ]
-        }
-      }
-    },
-    {
-      "body": {
-        "name": "DataFrame.map",
-        "brief": "Sets up the runtime expression and assigns the result to the specified column.",
-        "desc": "Adds a column with the specified name and the expression that evaluates to the column value. The evaluation of this expression happens inside of the Pixie engine (Carnot) thus cannot be directly accessed during compilation.  The expression can be a scalar value, a column from the same dataframe, or a [UDF](/reference/pxl/udf) function call. The syntax can be either `df['colname'] = expr` or `df.colname = expr`, the second option is simply syntactic sugar. The first form is slightly more expressive as you can set column names with spaces.       ",
-        "examples": [
-          {
-            "value": "```\ndf = px.DataFrame('process_stats')\n# Map scalar value to a column.\ndf['number'] = 12\n```"
-          },
-          {
-            "value": "```\ndf = px.DataFrame('http_events')\ndf.svc = df.ctx['svc']\n# Map column to another column name.\ndf.resp_body = df.resp_body\n```"
-          },
-          {
-            "value": "```\ndf = px.DataFrame('http_events')\n# Map expression to the column.\ndf['latency_ms'] = df['resp_latency_ns'] / 1.0e9\n```"
-          }
-        ]
-      },
-      "funcDoc": {
-        "args": [
-          {
-            "ident": "column_name",
-            "desc": "The name of the column to assign this value.",
-            "types": [
-              "str"
-            ]
-          },
-          {
-            "ident": "expr",
-            "desc": "The expression to evaluate in Carnot.",
-            "types": [
-              "ScalarExpression"
-            ]
-          }
-        ],
-        "returnType": {
-          "desc": "DataFrame with the new column added.",
-          "types": [
-            "px.DataFrame"
-          ]
-        }
-      }
-    },
-    {
-      "body": {
         "name": "DataFrame.head",
         "brief": "Return the first n rows.",
         "desc": "Returns a DataFrame with the first n rows of data.     ",
@@ -604,54 +454,59 @@
     },
     {
       "body": {
-        "name": "DataFrame.DataFrame",
-        "brief": "Sets up a DataFrame object from the specified table.",
-        "desc": "Sets up the loading procedure of the table into the rest of the execution engine. The returned value can be transformed, aggregated and filtered using the DataFrame methods.  Note that we are not actually loading data until the entire query is compiled, meaning that running this by itself won't do anything until a full pipeline is constructed.  DataFrame is able to load in any set of tables. See `px.GetSchemas()` for a list of tables and the columns that can be loaded.     ",
+        "name": "DataFrame.drop",
+        "brief": "Drops the specified columns from the DataFrame.",
+        "desc": "Returns a DataFrame with the specified columns dropped. Useful for removing columns you don't want to see in the final table result.  See `keep()` on how to specify which columns to keep.     ",
         "examples": [
           {
-            "value": "```\n# Select all columns\ndf = px.DataFrame('http_events', start_time='-5m')\n```"
+            "value": "```\ndf = px.DataFrame('process_stats', select=['upid', 'cpu_ktime_ns', 'cpu_utime_ns'])\n# Drop upid from df.\ndf = df.drop('upid')\n```"
           },
           {
-            "value": "```\n# Select subset of columns.\ndf = px.DataFrame('http_events', select=['upid', 'req_body'], start_time='-5m')\n```"
-          },
-          {
-            "value": "```\n# Absolute time specification.\ndf = px.DataFrame('http_events', start_time='2020-07-13 18:02:5.00 -0700')\n```"
+            "value": "```\ndf = px.DataFrame('process_stats', select=['upid', 'cpu_ktime_ns', 'cpu_utime_ns'])\n# Drop upid an cpu_ktime_ns from df.\ndf = df.drop(['upid', 'cpu_ktime_ns'])\n```"
           }
         ]
       },
       "funcDoc": {
         "args": [
           {
-            "ident": "table",
-            "desc": "The table name to load.",
+            "ident": "columns",
+            "desc": "DataFrame columns to drop, either as a string or a list.",
             "types": [
-              "string"
-            ]
-          },
-          {
-            "ident": "select",
-            "desc": "The columns of the table to load. Leave empty if you want to select all.",
-            "types": [
-              "List[str]]"
-            ]
-          },
-          {
-            "ident": "start_time",
-            "desc": "The earliest timestamp of data to load. Can be a relative time ie \"-5m\" or an absolute time in the following format \"2020-07-13 18:02:5.00 +0000\".",
-            "types": [
-              "px.Time"
-            ]
-          },
-          {
-            "ident": "end_time",
-            "desc": "The last timestamp of data to load. Can be a relative time ie \"-5m\" or an absolute time in the following format \"2020-07-13 18:02:5.00 +0000\".",
-            "types": [
-              "px.Time"
+              "Union[str,List[str]]"
             ]
           }
         ],
         "returnType": {
-          "desc": "DataFrame loaded from the table with the specified columns and time period.",
+          "desc": "DataFrame with the specified columns removed.",
+          "types": [
+            "px.DataFrame"
+          ]
+        }
+      }
+    },
+    {
+      "body": {
+        "name": "DataFrame.rolling",
+        "brief": "Groups the data by rolling windows.",
+        "desc": "Rolls up data into groups based on the rolling window that it belongs to. Used to define window aggregates, the streaming analog of batch aggregates.      ",
+        "examples": [
+          {
+            "value": "```\ndf = px.DataFrame('process_stats')\ndf = df.rolling('2s').agg(...)\n```"
+          }
+        ]
+      },
+      "funcDoc": {
+        "args": [
+          {
+            "ident": "window",
+            "desc": "the size of the rolling window.",
+            "types": [
+              "px.Duration"
+            ]
+          }
+        ],
+        "returnType": {
+          "desc": "DataFrame grouped into rolling windows. Must apply either a groupby or an aggregate on the returned DataFrame.",
           "types": [
             "px.DataFrame"
           ]
@@ -689,15 +544,12 @@
     },
     {
       "body": {
-        "name": "DataFrame.drop",
-        "brief": "Drops the specified columns from the DataFrame.",
-        "desc": "Returns a DataFrame with the specified columns dropped. Useful for removing columns you don't want to see in the final table result.  See `keep()` on how to specify which columns to keep.     ",
+        "name": "DataFrame.groupby",
+        "brief": "Groups the data in preparation for an aggregate.",
+        "desc": "Groups the data by the unique values in the passed in columns. At the current time we do not support standalone groupings, you must always follow the groupby() call with a call to `agg()`.     ",
         "examples": [
           {
-            "value": "```\ndf = px.DataFrame('process_stats', select=['upid', 'cpu_ktime_ns', 'cpu_utime_ns'])\n# Drop upid from df.\ndf = df.drop('upid')\n```"
-          },
-          {
-            "value": "```\ndf = px.DataFrame('process_stats', select=['upid', 'cpu_ktime_ns', 'cpu_utime_ns'])\n# Drop upid an cpu_ktime_ns from df.\ndf = df.drop(['upid', 'cpu_ktime_ns'])\n```"
+            "value": "```\n# Group by UPID and calculate maximum user time for the each\n# UPID group.\ndf = px.DataFrame('process_stats')\ndf = df.groupby('upid').agg(cpu_utime=('cpu_utime_ns', px.max))\n```"
           }
         ]
       },
@@ -705,14 +557,93 @@
         "args": [
           {
             "ident": "columns",
-            "desc": "DataFrame columns to drop, either as a string or a list.",
+            "desc": "DataFrame columns to group by, either as a string or a list.",
             "types": [
               "Union[str,List[str]]"
             ]
           }
         ],
         "returnType": {
+          "desc": "Grouped DataFrame. Must be followed by a call to `agg()`.",
+          "types": [
+            "px.DataFrame"
+          ]
+        }
+      }
+    },
+    {
+      "body": {
+        "name": "DataFrame.filter",
+        "brief": "Returns a DataFrame with only those rows that match the condition.",
+        "desc": "Filters for the rows in the DataFrame that match the boolean condition. Will error out if you don't pass in a boolean expression. The functions available are defined in [UDFs](/reference/pxl/udf).     ",
+        "examples": [
+          {
+            "value": "```\ndf = px.DataFrame('http_events')\n# Filter for only http requests that are greater than 100 milliseconds\ndf = df[df['resp_latency_ns'] \u003e 100 * 1000 * 1000]\n```"
+          }
+        ]
+      },
+      "funcDoc": {
+        "args": [
+          {
+            "ident": "key",
+            "desc": "DataFrame expression that evaluates to a bool. Filter keeps any row that causes the expression to evaluate to True.",
+            "types": [
+              "ScalarExpression"
+            ]
+          }
+        ],
+        "returnType": {
+          "desc": "DataFrame with only those rows that return True for the expression.",
+          "types": [
+            "px.DataFrame"
+          ]
+        }
+      }
+    },
+    {
+      "body": {
+        "name": "DataFrame.__getitem__",
+        "brief": "Keeps only the specified columns.",
+        "desc": "Returns a DataFrame with only the specified columns. Useful for pruning columns to a small set before data is displayed. See `drop()` on how to drop specific columns instead.     ",
+        "examples": [
+          {
+            "value": "```\ndf = px.DataFrame('process_stats', select=['upid', 'cpu_ktime_ns', 'rss_bytes'])\n# Keep only the upid and rss_bytes columns\ndf = df[['upid', 'rss_bytes']]\n```"
+          }
+        ]
+      },
+      "funcDoc": {
+        "args": [
+          {
+            "ident": "columns",
+            "desc": "DataFrame columns to keep.",
+            "types": [
+              "List[str]"
+            ]
+          }
+        ],
+        "returnType": {
           "desc": "DataFrame with the specified columns removed.",
+          "types": [
+            "px.DataFrame"
+          ]
+        }
+      }
+    },
+    {
+      "body": {
+        "name": "DataFrame.stream",
+        "brief": "Execute this DataFrame in streaming mode.",
+        "desc": "Returns the input DataFrame, but set to streaming mode. Streaming queries execute indefinitely, as opposed to batch queries which return a finite result.     ",
+        "examples": [
+          {
+            "value": "```\ndf = px.DataFrame('http_events').stream()\n```"
+          }
+        ]
+      },
+      "funcDoc": {
+        "args": [],
+        "returnType": {
+          "desc": "the parent DataFrame in streaming mode.",
           "types": [
             "px.DataFrame"
           ]
@@ -778,27 +709,96 @@
     },
     {
       "body": {
-        "name": "DataFrame.__getitem__",
-        "brief": "Keeps only the specified columns.",
-        "desc": "Returns a DataFrame with only the specified columns. Useful for pruning columns to a small set before data is displayed. See `drop()` on how to drop specific columns instead.     ",
+        "name": "DataFrame.DataFrame",
+        "brief": "Sets up a DataFrame object from the specified table.",
+        "desc": "Sets up the loading procedure of the table into the rest of the execution engine. The returned value can be transformed, aggregated and filtered using the DataFrame methods.  Note that we are not actually loading data until the entire query is compiled, meaning that running this by itself won't do anything until a full pipeline is constructed.  DataFrame is able to load in any set of tables. See `px.GetSchemas()` for a list of tables and the columns that can be loaded.     ",
         "examples": [
           {
-            "value": "```\ndf = px.DataFrame('process_stats', select=['upid', 'cpu_ktime_ns', 'rss_bytes'])\n# Keep only the upid and rss_bytes columns\ndf = df[['upid', 'rss_bytes']]\n```"
+            "value": "```\n# Select all columns\ndf = px.DataFrame('http_events', start_time='-5m')\n```"
+          },
+          {
+            "value": "```\n# Select subset of columns.\ndf = px.DataFrame('http_events', select=['upid', 'req_body'], start_time='-5m')\n```"
+          },
+          {
+            "value": "```\n# Absolute time specification.\ndf = px.DataFrame('http_events', start_time='2020-07-13 18:02:5.00 -0700')\n```"
           }
         ]
       },
       "funcDoc": {
         "args": [
           {
-            "ident": "columns",
-            "desc": "DataFrame columns to keep.",
+            "ident": "table",
+            "desc": "The table name to load.",
             "types": [
-              "List[str]"
+              "string"
+            ]
+          },
+          {
+            "ident": "select",
+            "desc": "The columns of the table to load. Leave empty if you want to select all.",
+            "types": [
+              "List[str]]"
+            ]
+          },
+          {
+            "ident": "start_time",
+            "desc": "The earliest timestamp of data to load. Can be a relative time ie \"-5m\" or an absolute time in the following format \"2020-07-13 18:02:5.00 +0000\".",
+            "types": [
+              "px.Time"
+            ]
+          },
+          {
+            "ident": "end_time",
+            "desc": "The last timestamp of data to load. Can be a relative time ie \"-5m\" or an absolute time in the following format \"2020-07-13 18:02:5.00 +0000\".",
+            "types": [
+              "px.Time"
             ]
           }
         ],
         "returnType": {
-          "desc": "DataFrame with the specified columns removed.",
+          "desc": "DataFrame loaded from the table with the specified columns and time period.",
+          "types": [
+            "px.DataFrame"
+          ]
+        }
+      }
+    },
+    {
+      "body": {
+        "name": "DataFrame.map",
+        "brief": "Sets up the runtime expression and assigns the result to the specified column.",
+        "desc": "Adds a column with the specified name and the expression that evaluates to the column value. The evaluation of this expression happens inside of the Pixie engine (Carnot) thus cannot be directly accessed during compilation.  The expression can be a scalar value, a column from the same dataframe, or a [UDF](/reference/pxl/udf) function call. The syntax can be either `df['colname'] = expr` or `df.colname = expr`, the second option is simply syntactic sugar. The first form is slightly more expressive as you can set column names with spaces.       ",
+        "examples": [
+          {
+            "value": "```\ndf = px.DataFrame('process_stats')\n# Map scalar value to a column.\ndf['number'] = 12\n```"
+          },
+          {
+            "value": "```\ndf = px.DataFrame('http_events')\ndf.svc = df.ctx['svc']\n# Map column to another column name.\ndf.resp_body = df.resp_body\n```"
+          },
+          {
+            "value": "```\ndf = px.DataFrame('http_events')\n# Map expression to the column.\ndf['latency_ms'] = df['resp_latency_ns'] / 1.0e9\n```"
+          }
+        ]
+      },
+      "funcDoc": {
+        "args": [
+          {
+            "ident": "column_name",
+            "desc": "The name of the column to assign this value.",
+            "types": [
+              "str"
+            ]
+          },
+          {
+            "ident": "expr",
+            "desc": "The expression to evaluate in Carnot.",
+            "types": [
+              "ScalarExpression"
+            ]
+          }
+        ],
+        "returnType": {
+          "desc": "DataFrame with the new column added.",
           "types": [
             "px.DataFrame"
           ]
@@ -807,25 +807,6 @@
     }
   ],
   "mutationDocs": [
-    {
-      "body": {
-        "name": "pxtrace.DeleteTracepoint",
-        "brief": "Deletes a tracepoint.",
-        "desc": "Deletes the tracepoint with the provided name, should it exist.  ",
-        "examples": []
-      },
-      "funcDoc": {
-        "args": [
-          {
-            "ident": "name",
-            "desc": "The name of the tracepoint.",
-            "types": [
-              "str"
-            ]
-          }
-        ]
-      }
-    },
     {
       "body": {
         "name": "pxtrace.UpsertTracepoint",
@@ -872,6 +853,25 @@
           }
         ]
       }
+    },
+    {
+      "body": {
+        "name": "pxtrace.DeleteTracepoint",
+        "brief": "Deletes a tracepoint.",
+        "desc": "Deletes the tracepoint with the provided name, should it exist.  ",
+        "examples": []
+      },
+      "funcDoc": {
+        "args": [
+          {
+            "ident": "name",
+            "desc": "The name of the tracepoint.",
+            "types": [
+              "str"
+            ]
+          }
+        ]
+      }
     }
   ],
   "pyApiDocs": {
@@ -885,18 +885,14 @@
         },
         "methods": [
           {
-            "def": {
-              "name": "def connect_to_cluster",
-              "declaration": "def connect_to_cluster(self, cluster: Union[str, pxapi.client.Cluster]) -\u003e pxapi.client.Conn",
-              "docstring": "Connect to a cluster.\n\nReturns a connection object that you can use to create `ScriptExecutor`s.\nYou may pass in a `ClusterID` string or a `Cluster` object that comes\nfrom `list_all_healthy_clusters()`."
-            }
+            "name": "def connect_to_cluster",
+            "declaration": "def connect_to_cluster(self, cluster: Union[str, pxapi.client.Cluster]) -\u003e pxapi.client.Conn",
+            "docstring": "Connect to a cluster.\n\nReturns a connection object that you can use to create `ScriptExecutor`s.\nYou may pass in a `ClusterID` string or a `Cluster` object that comes\nfrom `list_all_healthy_clusters()`."
           },
           {
-            "def": {
-              "name": "def list_healthy_clusters",
-              "declaration": "def list_healthy_clusters(self) -\u003e List[pxapi.client.Cluster]",
-              "docstring": "Lists all of the healthy clusters that you can access."
-            }
+            "name": "def list_healthy_clusters",
+            "declaration": "def list_healthy_clusters(self) -\u003e List[pxapi.client.Cluster]",
+            "docstring": "Lists all of the healthy clusters that you can access."
           }
         ]
       },
@@ -908,18 +904,14 @@
         },
         "methods": [
           {
-            "def": {
-              "name": "def name",
-              "declaration": "def name(self) -\u003e str",
-              "docstring": "Returns the name if that info exists, otherwise returns the id."
-            }
+            "name": "def name",
+            "declaration": "def name(self) -\u003e str",
+            "docstring": "Returns the name if that info exists, otherwise returns the id."
           },
           {
-            "def": {
-              "name": "def passthrough",
-              "declaration": "def passthrough(self) -\u003e bool",
-              "docstring": ""
-            }
+            "name": "def passthrough",
+            "declaration": "def passthrough(self) -\u003e bool",
+            "docstring": ""
           }
         ]
       },
@@ -931,18 +923,14 @@
         },
         "methods": [
           {
-            "def": {
-              "name": "def name",
-              "declaration": "def name(self) -\u003e str",
-              "docstring": "Get the name of the cluster for this connection."
-            }
+            "name": "def name",
+            "declaration": "def name(self) -\u003e str",
+            "docstring": "Get the name of the cluster for this connection."
           },
           {
-            "def": {
-              "name": "def prepare_script",
-              "declaration": "def prepare_script(self, script_str: str) -\u003e pxapi.client.ScriptExecutor",
-              "docstring": "Create a new ScriptExecutor for the script to run on this connection."
-            }
+            "name": "def prepare_script",
+            "declaration": "def prepare_script(self, script_str: str) -\u003e pxapi.client.ScriptExecutor",
+            "docstring": "Create a new ScriptExecutor for the script to run on this connection."
           }
         ]
       },
@@ -954,46 +942,34 @@
         },
         "methods": [
           {
-            "def": {
-              "name": "def add_callback",
-              "declaration": "def add_callback(self, table_name: str, fn: Callable[[pxapi.data.Row], NoneType] ) -\u003e None",
-              "docstring": "Adds a callback fn that will be invoked on every row of `table_name` as\nthey arrive.\n\nCallbacks are not invoked until you call `run()` (or `run_async()`) on\nthe object.\n\nIf you `add_callback` on a table not produced by the script, `run()`(or `run_async()`) will\nraise a ValueError when the underlying gRPC channel closes.\n\nThe internals of `ScriptExecutor` use the python async api and the callback `fn`\nwill be called concurrently while the ScriptExecutor is running. Note that callbacks\nthemselves should not be async functions.\n\nCallbacks will block the rest of script execution so expensive and unending\ncallbacks should not be used.\n\nRaises:\n    ValueError: If called on a table that's already been passed as arg to\n        `subscribe` or `add_callback`.\n    ValueError: If called after `run()` or `run_async()` for a particular\n        `ScriptExecutor`"
-            }
+            "name": "def add_callback",
+            "declaration": "def add_callback(self, table_name: str, fn: Callable[[pxapi.data.Row], NoneType] ) -\u003e None",
+            "docstring": "Adds a callback fn that will be invoked on every row of `table_name` as\nthey arrive.\n\nCallbacks are not invoked until you call `run()` (or `run_async()`) on\nthe object.\n\nIf you `add_callback` on a table not produced by the script, `run()`(or `run_async()`) will\nraise a ValueError when the underlying gRPC channel closes.\n\nThe internals of `ScriptExecutor` use the python async api and the callback `fn`\nwill be called concurrently while the ScriptExecutor is running. Note that callbacks\nthemselves should not be async functions.\n\nCallbacks will block the rest of script execution so expensive and unending\ncallbacks should not be used.\n\nRaises:\n    ValueError: If called on a table that's already been passed as arg to\n        `subscribe` or `add_callback`.\n    ValueError: If called after `run()` or `run_async()` for a particular\n        `ScriptExecutor`"
           },
           {
-            "def": {
-              "name": "def results",
-              "declaration": "def results(self, table_name: str ) -\u003e Generator[pxapi.data.Row, NoneType, NoneType]",
-              "docstring": "Runs script and return results for the table.\nExamples:\n    for row in script.results(\"http_table\"):\n        print(row)\nRaises:\n    ValueError: If `table_name` is never sent during lifetime of script.\n    ValueError: If called after `run()` or `run_async()` for a particular\n        `ScriptExecutor`."
-            }
+            "name": "def results",
+            "declaration": "def results(self, table_name: str ) -\u003e Generator[pxapi.data.Row, NoneType, NoneType]",
+            "docstring": "Runs script and return results for the table.\nExamples:\n    for row in script.results(\"http_table\"):\n        print(row)\nRaises:\n    ValueError: If `table_name` is never sent during lifetime of script.\n    ValueError: If called after `run()` or `run_async()` for a particular\n        `ScriptExecutor`."
           },
           {
-            "def": {
-              "name": "def run",
-              "declaration": "def run(self) -\u003e None",
-              "docstring": "Executes the script synchronously.\n\nCalls `run_async()` but hides the asyncio details from users.\nIf any errors occur over the lifetime of any connection, this will raise an error.\n\nRaises:\n    ValueError: If any callbacks are on tables that a `ScriptExecutor` never receives.\n    ValueError: If called after `run()` or `run_async()` for a particular\n        `ScriptExecutor`."
-            }
+            "name": "def run",
+            "declaration": "def run(self) -\u003e None",
+            "docstring": "Executes the script synchronously.\n\nCalls `run_async()` but hides the asyncio details from users.\nIf any errors occur over the lifetime of any connection, this will raise an error.\n\nRaises:\n    ValueError: If any callbacks are on tables that a `ScriptExecutor` never receives.\n    ValueError: If called after `run()` or `run_async()` for a particular\n        `ScriptExecutor`."
           },
           {
-            "def": {
-              "name": "def run_async",
-              "declaration": "def run_async(self) -\u003e None",
-              "docstring": "Runs the script asynchronously using asyncio.\n\nSame as `run()` except you can directly control whether other tasks\nshould be run concurrently while the script  is running.\n\nRaises:\n    ValueError: If any callbacks are on tables that a `ScriptExecutor` never receives.\n    ValueError: If called after `run()` or `run_async()` for a particular\n        `ScriptExecutor`."
-            }
+            "name": "def run_async",
+            "declaration": "def run_async(self) -\u003e None",
+            "docstring": "Runs the script asynchronously using asyncio.\n\nSame as `run()` except you can directly control whether other tasks\nshould be run concurrently while the script  is running.\n\nRaises:\n    ValueError: If any callbacks are on tables that a `ScriptExecutor` never receives.\n    ValueError: If called after `run()` or `run_async()` for a particular\n        `ScriptExecutor`."
           },
           {
-            "def": {
-              "name": "def subscribe",
-              "declaration": "def subscribe(self, table_name: str) -\u003e pxapi.client.TableSub",
-              "docstring": "Returns an async generator that outputs rows for the table.\n\nRaises:\n    ValueError: If called on a table that's already been passed as arg to\n        `subscribe` or `add_callback`.\n    ValueError: If called after `run()` or `run_async()` for a particular\n        `ScriptExecutor`"
-            }
+            "name": "def subscribe",
+            "declaration": "def subscribe(self, table_name: str) -\u003e pxapi.client.TableSub",
+            "docstring": "Returns an async generator that outputs rows for the table.\n\nRaises:\n    ValueError: If called on a table that's already been passed as arg to\n        `subscribe` or `add_callback`.\n    ValueError: If called after `run()` or `run_async()` for a particular\n        `ScriptExecutor`"
           },
           {
-            "def": {
-              "name": "def subscribe_all_tables",
-              "declaration": "def subscribe_all_tables(self ) -\u003e Callable[[], AsyncGenerator[pxapi.client.TableSub, NoneType]]",
-              "docstring": "Returns an async generator that outputs table subscriptions as they arrive.\n\nYou can use this generator to call PxL scripts without knowing the tables\nthat are output beforehand. If you do know the tables beforehand, you should\n`subscribe`, `add_callback` or even `results` instead to prevent your api from\nkeeping data for tables that you don't use.\n\nThis generator will only start iterating after `run_async()` has been\ncalled. For the best performance, you will want to call the consumer of\nthe object returned by `subscribe_all_tables` concurrently with `run_async()`"
-            }
+            "name": "def subscribe_all_tables",
+            "declaration": "def subscribe_all_tables(self ) -\u003e Callable[[], AsyncGenerator[pxapi.client.TableSub, NoneType]]",
+            "docstring": "Returns an async generator that outputs table subscriptions as they arrive.\n\nYou can use this generator to call PxL scripts without knowing the tables\nthat are output beforehand. If you do know the tables beforehand, you should\n`subscribe`, `add_callback` or even `results` instead to prevent your api from\nkeeping data for tables that you don't use.\n\nThis generator will only start iterating after `run_async()` has been\ncalled. For the best performance, you will want to call the consumer of\nthe object returned by `subscribe_all_tables` concurrently with `run_async()`"
           }
         ]
       },
@@ -1021,11 +997,9 @@
         },
         "methods": [
           {
-            "def": {
-              "name": "def encrypt_options",
-              "declaration": "def encrypt_options(self) -\u003e src.api.proto.vizierpb.vizierapi_pb2.EncryptionOptions",
-              "docstring": ""
-            }
+            "name": "def encrypt_options",
+            "declaration": "def encrypt_options(self) -\u003e src.api.proto.vizierpb.vizierapi_pb2.EncryptionOptions",
+            "docstring": ""
           }
         ]
       }
@@ -1061,31 +1035,17 @@
   "tracepointFieldDocs": [
     {
       "body": {
-        "name": "pxtrace.SharedObject",
-        "brief": "Defines a shared object target for Tracepoints.",
+        "name": "pxtrace.FunctionLatency",
+        "brief": "Specifies a function latency to trace.",
+        "desc": "Computes the function latency, from entry to return. The measured latency includes includes time spent in sub-calls.  ",
         "examples": []
       },
       "funcDoc": {
-        "args": [
-          {
-            "ident": "name",
-            "desc": "The name of the shared object.",
-            "types": [
-              "str"
-            ]
-          },
-          {
-            "ident": "upid",
-            "desc": "A process which loads the shared object.",
-            "types": [
-              "px.UPID"
-            ]
-          }
-        ],
+        "args": [],
         "returnType": {
-          "desc": "A pointer to the SharedObject that can be passed as a target to UpsertTracepoint.",
+          "desc": "A materialized column pointer to use in output table definitions.",
           "types": [
-            "SharedObject"
+            "px.TracingField"
           ]
         }
       }
@@ -1102,23 +1062,6 @@
           "desc": "KProbe target that can be passed into UpsertTracepoint.",
           "types": [
             "KProbeTarget"
-          ]
-        }
-      }
-    },
-    {
-      "body": {
-        "name": "pxtrace.FunctionLatency",
-        "brief": "Specifies a function latency to trace.",
-        "desc": "Computes the function latency, from entry to return. The measured latency includes includes time spent in sub-calls.  ",
-        "examples": []
-      },
-      "funcDoc": {
-        "args": [],
-        "returnType": {
-          "desc": "A materialized column pointer to use in output table definitions.",
-          "types": [
-            "px.TracingField"
           ]
         }
       }
@@ -1208,6 +1151,37 @@
           "desc": "A materialized column pointer to use in output table definitions.",
           "types": [
             "px.TracingField"
+          ]
+        }
+      }
+    },
+    {
+      "body": {
+        "name": "pxtrace.SharedObject",
+        "brief": "Defines a shared object target for Tracepoints.",
+        "examples": []
+      },
+      "funcDoc": {
+        "args": [
+          {
+            "ident": "name",
+            "desc": "The name of the shared object.",
+            "types": [
+              "str"
+            ]
+          },
+          {
+            "ident": "upid",
+            "desc": "A process which loads the shared object.",
+            "types": [
+              "px.UPID"
+            ]
+          }
+        ],
+        "returnType": {
+          "desc": "A pointer to the SharedObject that can be passed as a target to UpsertTracepoint.",
+          "types": [
+            "SharedObject"
           ]
         }
       }


### PR DESCRIPTION
Python API doc format was incorrect in the latest update to the docs. Turns out the generator nested the method docs in the wrong format. This change is the result of fixing that generation. 
Signed-off-by: Phillip Kuznetsov <pkuznetsov@pixielabs.ai>