### PR TITLE
Update docs to say that the minimum recommended PEM memory is 1Gi

### DIFF
--- a/content/en/01-about-pixie/05-faq.md
+++ b/content/en/01-about-pixie/05-faq.md
@@ -81,7 +81,7 @@ Yes. Pixie Community Cloud is a hosted version of Pixie. Pixie stores all data o
 
 Pixie stores the data it collects in-memory on the nodes in your cluster; no data is sent to a centralized backend outside of the cluster. This is true for both self-hosted Pixie and [Pixie Community Cloud](#general-does-pixie-offer-a-hosted-cloud-offering).
 
-Pixie has a [2GiB memory requirement](/installing-pixie/requirements/#memory) per node. After installing Pixie, it is normal to see a temporary increase in memory usage of the `vizier-pem` pods as they begin to fill their data tables.
+Pixie has a [1GiB memory requirement](/installing-pixie/requirements/#memory) per node. After installing Pixie, it is normal to see a temporary increase in memory usage of the `vizier-pem` pods as they begin to fill their data tables.
 
 ### How much data does Pixie store?
 
@@ -227,7 +227,7 @@ Continuous profiling currently only supports Go/C++/Rust. The [Roadmap](/about-p
 
 This is expected behavior. Pixie stores the data it collects in-memory on the nodes in your cluster; data is not sent to any centralized backend cloud outside of the cluster. So what you are observing is simply the data that it is collecting.
 
-Pixie has a 2GiB memory requirement per node. This limit can be configured with the `--pemMemoryLimit` flag when deploying Pixie with the CLI/Helm. We do not recommend using a value less than 2GiB.
+Pixie has a minimum 1GiB memory requirement per node. The default deployment is 2GiB of memory. This limit can be configured with the `--pem_memory_limit` flag when deploying Pixie. Using a value less than 1GiB is not currently recommended.
 
 ### Troubleshooting Pixie tracepoint scripts
 

--- a/content/en/02-installing-pixie/01-requirements.md
+++ b/content/en/02-installing-pixie/01-requirements.md
@@ -45,9 +45,9 @@ For local development, we recommend using Minikube with a VM driver (`kvm2` on L
 
 Memory requirements for your cluster nodes are as follows:
 
-|                       | Minimum   | Notes                                                   |
-| :-------------------  | :-------- | :------------------------------------------------------ |
-| Memory                | 2GiB      | To accommodate application pods, 8GiB+ is recommended.  |
+| Minimum   | Notes                                                                  |
+| :-------- | :--------------------------------------------------------------------- |
+| 1GiB      | To accommodate application pods, 4GiB+ total per node is recommended.  |
 
 ## CPU
 

--- a/content/en/02-installing-pixie/03-install-guides/01-community-cloud-for-pixie.md
+++ b/content/en/02-installing-pixie/03-install-guides/01-community-cloud-for-pixie.md
@@ -55,6 +55,9 @@ px deploy
 
 # Deploy the Pixie Platform in your K8s cluster (OLM already exists on cluster).
 px deploy --deploy_olm=false
+
+# Deploy Pixie with a specific memory limit (2Gi is the default, 1Gi is the minimum recommended)
+px deploy --pem_memory_limit=1Gi
 ```
 
 Pixie deploys the following pods to your cluster. Note that the number of `vizier-pem` pods correlates with the number of nodes in your cluster, so your  deployment may contain more PEM pods.

--- a/content/en/02-installing-pixie/03-install-guides/02-self-hosted-pixie.md
+++ b/content/en/02-installing-pixie/03-install-guides/02-self-hosted-pixie.md
@@ -164,6 +164,9 @@ px deploy --dev_cloud_namespace plc
 
 # Deploy the Pixie Platform in your K8s cluster (OLM already exists on cluster).
 px deploy  --dev_cloud_namespace plc --deploy_olm=false
+
+# Deploy Pixie with a specific memory limit (2Gi is the default, 1Gi is the minimum recommended)
+px deploy --dev_cloud_namespace plc --pem_memory_limit=1Gi
 ```
 
 Pixie will deploy pods to the `pl`, `plc`, `px-operator`, and `olm`(if deploying the OLM) namespaces.

--- a/content/en/02-installing-pixie/04-install-schemes/01-cli.md
+++ b/content/en/02-installing-pixie/04-install-schemes/01-cli.md
@@ -104,6 +104,9 @@ px deploy
 
 # Deploy the Pixie Platform in your K8s cluster (OLM already exists on cluster).
 px deploy --deploy_olm=false
+
+# Deploy Pixie with a specific memory limit (2Gi is the default, 1Gi is the minimum recommended)
+px deploy --pem_memory_limit=1Gi
 ```
 
 Pixie will deploy pods to the `pl`, `px-operator`, and `olm`(if deploying the OLM) namespaces.

--- a/content/en/02-installing-pixie/04-install-schemes/02-yaml.md
+++ b/content/en/02-installing-pixie/04-install-schemes/02-yaml.md
@@ -48,6 +48,9 @@ px deploy --extract_yaml <NAME_OF_PIXIE_YAMLS_FOLDER> --deploy_key <PIXIE_DEPLOY
 # Extract YAML (OLM already exists on cluster).
 px deploy --extract_yaml <NAME_OF_PIXIE_YAMLS_FOLDER> --deploy_key <PIXIE_DEPLOYMENT_KEY> --deploy_olm=false
 
+# Deploy Pixie with a specific memory limit (2Gi is the default, 1Gi is the minimum recommended)
+px deploy --extract_yaml <NAME_OF_PIXIE_YAMLS_FOLDER> --deploy_key <PIXIE_DEPLOYMENT_KEY> --pem_memory_limit=1Gi
+
 ```
 
 **Note:** The extracted YAMls does not include manifests for each sub-component of Pixie. It includes manifests for etcd, NATS and the cloud-connector service which downloads the manifests for the necessary services and daemonsets.

--- a/content/en/02-installing-pixie/04-install-schemes/03-helm.md
+++ b/content/en/02-installing-pixie/04-install-schemes/03-helm.md
@@ -55,6 +55,9 @@ helm install pixie pixie-operator/pixie-operator-chart --set deployKey=<deploy-k
 
 # Install the Pixie chart (OLM already exists on cluster).
 helm install pixie pixie-operator/pixie-operator-chart --set deployKey=<deploy-key-goes-here> --set clusterName=<cluster-name> --namespace pl --create-namespace --set deployOLM=false
+
+# Install Pixie with a memory limit for the PEM pods (per node). 2Gi is the default, 1Gi is the minimum recommended.
+helm install pixie pixie-operator/pixie-operator-chart --set deployKey=<deploy-key-goes-here> --set clusterName=<cluster-name> --namespace pl --create-namespace --set deployOLM=false --set pemMemoryLimit=1Gi
 ```
 
 Pixie will deploy pods to the `pl`, `px-operator`, and `olm`(if deploying the OLM) namespaces.

--- a/content/en/05-reference/01-admin/04-deploy-options.md
+++ b/content/en/05-reference/01-admin/04-deploy-options.md
@@ -27,6 +27,10 @@ Certain labels are reserved for internal use by Pixie. The following are reserve
 - `“vizier-updater-dep"`
 - `“app"`
 
+## PEM Memory Usage
+
+Pixie deploys its PEMs as a DaemonSet on your cluster in order to collect and store telemetry data. The default memory limit is 2Gi per PEM. The lowest recommended value is [1Gi](/installing-pixie/requirements/#memory) per PEM. You have the option to configure this value via the `--pem_memory_limit` flag in the CLI/YAML (`--set pemMemoryLimit=<limit>` in Helm).
+
 ## Data Access
 
 You can configure Pixie's data access mode in order to control what data can be displayed when executing a script.


### PR DESCRIPTION
More documentation on how to size Vizier memory will come as a next step, but for now let's get the word out that PEM memory usage has a minimum of 1Gi now (with a 2Gi default).

Signed-off-by: Natalie Serrino <nserrino@pixielabs.ai>