### PR TITLE
Fix rendering UDFs with variable arguments

### DIFF
--- a/src/templates/udfDocs.tsx
+++ b/src/templates/udfDocs.tsx
@@ -89,13 +89,13 @@ const UdfDocsTemplate = ((props: any) => {
               </TableRow>
             </TableHead>
             <TableBody>
-              {functions[0].definition.inputs ? functions[0].definition.inputs.map((i, index) => (
+              {functions[0].definition.inputs ? functions[0].definition.inputs.map((arg, index) => (
                 <TableRow>
-                  <TableCell align='left'>{i.ident}</TableCell>
+                  <TableCell align='left'>{arg.ident}</TableCell>
                   <TableCell align='left'>
-                    {[...new Set(functions.map((f) => f.definition).map((d) => d.inputs[index].type))].join(' / ')}
+                    {[...new Set(functions.filter((f) => !!f.definition.inputs[index]).map((f) => f.definition.inputs[index].type))].join(' / ')}
                   </TableCell>
-                  <TableCell align='left'>{i.desc}</TableCell>
+                  <TableCell align='left'>{arg.desc}</TableCell>
                 </TableRow>
               )) : ''}
 


### PR DESCRIPTION
A new UDF has variable arguments and we need to support them.
Tested by using that new generated doc file and made sure it works. Previously that file failed here:
https://github.com/pixie-io/docs.px.dev/pull/189
Signed-off-by: Phillip Kuznetsov <pkuznetsov@pixielabs.ai>