### PR TITLE
Highlighting code-blocks should not highlight line numbers

### DIFF
--- a/src/components/mdxComponents/codeRenderer.tsx
+++ b/src/components/mdxComponents/codeRenderer.tsx
@@ -33,6 +33,7 @@ const LineNumber = withStyles((theme) => ({
     paddingRight: '20px',
     color: theme.palette.type === 'light' ? '#ccc' : '#e0ebf7',
     fontFamily: '"Roboto Mono", Monospace',
+    userSelect: 'none',
   },
 }
 ))(({ lineNumber, classes }: any) => (<span className={classes.lineBlock}>{lineNumber}</span>));


### PR DESCRIPTION
Fixes https://github.com/pixie-io/docs.px.dev/issues/190

Signed-off-by: Cristian Postescu <postescu@gmail.com>