### PR TITLE
Clarify HTTP2 support.

### DIFF
--- a/content/en/01-about-pixie/02-data-sources.md
+++ b/content/en/01-about-pixie/02-data-sources.md
@@ -34,7 +34,7 @@ Pixie automatically traces the following protocols:
 | Protocol      | Support             | Notes                          |
 | :------------ | :------------------ | :----------------------------- |
 | HTTP          | Supported           |                                |
-| HTTP2/gRPC    | Partially Supported | Currently only for Golang apps with [debug information](/reference/admin/debug-info). |
+| HTTP2         | Supported for [Golang gRPC](https://github.com/grpc/grpc-go) (with and without TLS). | Golang apps must have [debug information](/reference/admin/debug-info). |
 | DNS           | Supported           |                                |
 | NATS          | Supported           | Requires a NATS build with [debug information](/reference/admin/debug-info). |
 | MySQL         | Supported           |                                |


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/66266496/175134012-7224cec6-2336-46c7-ae2b-3a4a41b64371.png)

After:
<img width="607" alt="image" src="https://user-images.githubusercontent.com/66266496/175134179-60b050b3-04d1-4bbb-9b0a-915fd1abbe28.png">


Signed-off-by: Hannah Troisi <htroisi@pixielabs.ai>