### PR TITLE
Update PxL script tutorial to account for `metric_counter` type columns.

### DIFF
--- a/content/en/04-tutorials/02-pxl-scripts/01-write-pxl-scripts/01-custom-pxl-scripts-1.md
+++ b/content/en/04-tutorials/02-pxl-scripts/01-write-pxl-scripts/01-custom-pxl-scripts-1.md
@@ -1,15 +1,17 @@
 ---
-title: "Tutorial #1: Writing your first PxL script"
-metaTitle: "Tutorials | PxL Scripts | Write Custom Scripts | Writing your first PxL script"
+title: "Tutorial #1: Write your first PxL script"
+metaTitle: "Tutorials | PxL Scripts | Write Custom Scripts | Tutorial #1: Write your first PxL script"
 metaDescription: ""
 order: 1
 redirect_from:
     - /tutorials/pxl-scripts/pxl-scripts-1
 ---
 
-In this tutorial series, we will write a PxL script to analyze the volume of traffic coming in and out of each pod in your cluster (total bytes received vs total bytes sent). In this first tutorial, we will write a script to query a table of traced network connection data provided by Pixie's no-instrumentation monitoring platform.
+This tutorial series demonstrates how to write a PxL script to analyze the volume of traffic coming in and out of each pod in your cluster (total bytes received vs total bytes sent).
 
-## Writing Your First PxL Script
+In Part 1 of this tutorial, we will write a very basic PxL script which simply queries a table of traced network connection data provided by Pixie's no-instrumentation monitoring platform.
+
+## The most basic PxL script
 
 1. Create a new PxL file called `my_first_script.pxl`:
 
@@ -17,7 +19,7 @@ In this tutorial series, we will write a PxL script to analyze the volume of tra
 touch my_first_script.pxl
 ```
 
-2. Open this file in your favorite editor and add the following lines. To copy the code, hover over the top-right corner of the codeblock and click the copy icon.
+2. Open this file in your favorite editor and add the following lines. To copy the code, hover over the top-right corner of the code block and click the copy icon.
 
 ```python:numbers
 # Import Pixie's module for querying data
@@ -30,29 +32,31 @@ df = px.DataFrame(table='conn_stats', start_time='-30s')
 px.display(df)
 ```
 
-Every script begins witih importing Pixie's `px` module. This is Pixie's main library for querying data.
+> On `line 2` we import Pixie's `px` module. This is Pixie's main library for querying data.
 
-Pixie's scripts are written using the [Pixie Language](/reference/pxl) (PxL), a DSL that follows the API of the the popular Python data processing library [Pandas](https://pandas.pydata.org/docs/user_guide/index.html). Pandas uses DataFrames to represent tables of data.
+> Pixie's scripts are written using the [Pixie Language](/reference/pxl) (PxL), a DSL that follows the API of the the popular Python data processing library [Pandas](https://pandas.pydata.org/docs/user_guide/index.html). Pandas uses DataFrames to represent tables of data.
 
-On line `5` we load the last `30` seconds of the data from the `conn_stats` table into a DataFrame. The `conn_stats` table contains high-level statistics about the connections (i.e. client-server pairs) that Pixie has traced in your cluster.
+> On `line 5` we load the last 30 seconds of data from the `conn_stats` table into a [DataFrame](/reference/pxl/operators/dataframe.dataframe).
 
-Finally, we display the table using `px.display()`.
+> The [`conn_stats`](/reference/datatables/conn_stats/) table contains high-level statistics about the connections (i.e. client-server pairs) that Pixie has traced in your cluster.
 
-3. Run this script using Pixie's Live CLI. If you aren't familiar with Pixie's CLI tool, check out [Navigating the CLI](/using-pixie/using-cli).
+> On `line 8` we display the table using [`px.display()`](/reference/pxl/operators/px.display/).
+
+3. Run this script using Pixie's Live CLI:
 
 ```bash
 px live -f my_first_script.pxl
 ```
 
-Your CLI should output something similar to the following table:
+<Alert variant="outlined" severity="info">
+  If you aren't familiar with Pixie's CLI tool, check out the <a href="/using-pixie/using-cli">Using the CLI</a> guide.
+</Alert>
+
+> Your CLI should output something similar to the following table:
 
 <svg title='Output of my_first_script.pxl in the Live CLI.' src='pxl-scripts/first-script-1.png'/>
 
-If your output table is empty, try increasing the value of the `start_time` string on line `5`. Save the script, exit the Live CLI using `ctrl+c`, and re-run Step 3.
-
-## Inspecting the Output
-
-This script outputs a table of data representing the last 30 seconds of the traced client-server connections in your cluster. Columns include:
+This PxL script outputs a table of data representing the last 30 seconds of the traced client-server connections in your cluster. Columns include:
 
 - `time_`: Timestamp when the data record was collected.
 - `upid` An opaque numeric ID that globally identifies a running process inside the cluster.
@@ -67,11 +71,16 @@ This script outputs a table of data representing the last 30 seconds of the trac
 - `bytes_sent`: The number of bytes sent to the remote endpoint(s).
 - `bytes_recv`: The number of bytes received from the remote endpoint(s).
 
-### (Optional) Running px/schemas
+<Alert variant="outlined" severity="info">
+  If your output table is empty, try increasing the `start_time` value on line 5. If you modify the `start_time`, you'll need to save the script, exit the Live CLI using `ctrl+c`, and re-run the command in Step 3.
+</Alert>
 
-You can find these column descriptions as well as descriptions for all of the data provided by Pixie by running the pre-built `px/schemas` script:
+## (Optional) Running px/schemas
+
+You can find the [`conn_stats`](/reference/datatables/conn_stats/) column descriptions as well as descriptions for all of the data tables provided by Pixie in the [data table reference docs](/reference/datatables/) or by running the pre-built `px/schemas` script:
 
 1. Exit the Live CLI using `ctrl+c`
+
 2. Run the `px/schemas` script:
 
 ```bash
@@ -82,9 +91,9 @@ px live px/schemas
 
 <svg title='conn_stats table schema from the px/schemas script.' src='pxl-scripts/first-script-2.png'/>
 
-## More Fun with DataFrames
+## (Optional) More fun with DataFrames
 
-[DataFrame](/reference/pxl/operators/dataframe/) initialization supports `end_time` for queries requiring more precise time periods. If an `end_time` isn't provided, the DataFrame will return all events up to the current time.
+[DataFrame](/reference/pxl/operators/dataframe.dataframe) initialization supports `end_time` for queries requiring more precise time periods. If an `end_time` isn't provided, the DataFrame will return all events up to the current time.
 
 ```python:numbers
 import px
@@ -94,9 +103,7 @@ df = px.DataFrame(table='conn_stats', start_time='-60s', end_time='-30s')
 px.display(df)
 ```
 
-Don't forget to save your script, exit the Live CLI using `ctrl+c`,  and re-run the script `px live -f ~/my_first_script.pxl` to update the results.
-
-You can [drop](/reference/pxl/operators/drop/) columns using the `df.drop()` command.
+You can [drop](/reference/pxl/operators/dataframe.drop/) columns using the `df.drop()` command.
 
 ```python:numbers
 import px
@@ -109,7 +116,7 @@ df = df.drop(['conn_open', 'conn_close', 'bytes_sent', 'bytes_recv'])
 px.display(df)
 ```
 
-Alternatively, you can use [keep](/reference/pxl/operators/keep/) to return a DataFrame with only the specified columns. This can be used to reorder the columns in the output.
+Alternatively, you can use [keep](/reference/pxl/operators/dataframe.__getitem__) to return a DataFrame with only the specified columns. This can be used to reorder the columns in the output.
 
 ```python:numbers
 import px
@@ -122,7 +129,7 @@ df = df[['remote_addr', 'conn_open', 'conn_close']]
 px.display(df)
 ```
 
-If you only need a few columns from a table, use the [DataFrame](/reference/pxl/operators/dataframe/)'s `select` argument instead.
+If you only need a few columns from a table, use the [DataFrame](/reference/pxl/operators/dataframe.dataframe)'s `select` argument instead.
 
 ```python:numbers
 import px
@@ -133,7 +140,7 @@ df = px.DataFrame(table='conn_stats', select=['remote_addr', 'conn_open', 'conn_
 px.display(df)
 ```
 
-To [filter](/reference/pxl/operators/filter/) the rows in the DataFrame by the `role` column:
+To [filter](/reference/pxl/operators/dataframe.filter) the rows in the DataFrame by the `role` column:
 
 ```python:numbers
 import px
@@ -146,7 +153,7 @@ df = df[df.role == 1]
 px.display(df)
 ```
 
-If you want to see a small sample of data, you can [limit](/reference/pxl/operators/limit/) the number of rows in the returned DataFrame to the first n rows (line 4).
+If you want to see a small sample of data, you can [limit](/reference/pxl/operators/dataframe.head) the number of rows in the returned DataFrame to the first n rows (line 4).
 
 ```python:numbers
 import px
@@ -163,7 +170,7 @@ px.display(df)
 
 Congratulations, you built your first script!
 
-In part 2 of this tutorial, we will expand this script to produce a table that summarizes the total amount of traffic coming in and out of each of the pods in your cluster.
+In [Tutorial #2](/tutorials/pxl-scripts/write-pxl-scripts/custom-pxl-scripts-2), we will expand this PxL script to produce a table that summarizes the total amount of traffic coming in and out of each of the pods in your cluster.
 
 This video summarizes the content in part 1 and part 2 of this tutorial:
 <YouTube youTubeId="is-qWZiKJ4I" />

--- a/content/en/04-tutorials/02-pxl-scripts/01-write-pxl-scripts/02-custom-pxl-scripts-2.md
+++ b/content/en/04-tutorials/02-pxl-scripts/01-write-pxl-scripts/02-custom-pxl-scripts-2.md
@@ -1,15 +1,13 @@
 ---
 title: "Tutorial #2: Finish your first PxL Script"
-metaTitle: "Tutorials | PxL Scripts | Write Custom Scripts | Tutorial #3: Finish your first PxL Script"
+metaTitle: "Tutorials | PxL Scripts | Write Custom Scripts | Tutorial #2: Finish your first PxL Script"
 metaDescription: ""
 order: 2
 redirect_from:
     - /tutorials/pxl-scripts/pxl-scripts-2
 ---
 
-## Overview
-
-[Tutorial #1](/tutorials/pxl-scripts/write-pxl-scripts/custom-pxl-scripts-1) wrote a simple script to query the `conn_stats` table of data provided by Pixie's platform:
+In [Tutorial #1](/tutorials/pxl-scripts/write-pxl-scripts/custom-pxl-scripts-1) we wrote a simple script to query the [`conn_stats`](/reference/datatables/conn_stats/) table of data provided by Pixie's platform:
 
 ```python:numbers
 # Import Pixie's module for querying data
@@ -22,15 +20,15 @@ df = px.DataFrame(table='conn_stats', start_time='-30s')
 px.display(df)
 ```
 
-This tutorial will modify that script to produce a table that summarizes the total amount of traffic coming in and out of each of the pods in your cluster.
+This tutorial will expand this PxL script to produce a table that summarizes the total amount of traffic coming in and out of each of the pods in your cluster.
 
 ## Adding Context
 
-The [`ctx`](/reference/pxl/operators/metadata/) function provides extra Kubernetes metadata context based on the existing information in your DataFrame.
+The [`ctx`](/reference/pxl/operators/dataframe.ctx.__getitem__/) function provides extra Kubernetes metadata context based on the existing information in your DataFrame.
 
-Because the `conn_stats` table contains the `upid` (an opaque numeric ID that globally identifies a process running inside the cluster), PxL can infer the `namespace`, `service`, `pod`, `container` and `cmd` (command) that initiated the connection.
+Because the [`conn_stats`](/reference/datatables/conn_stats/) table contains the `upid` (an opaque numeric ID that globally identifies a process running inside the cluster), PxL can infer the namespace, service, pod, container and command that initiated the connection.
 
-We'll add columns for `pod` and `service` to our script.
+Let's add columns for `pod` and `service` to our script.
 
 ```python:numbers
 # Import Pixie's module for querying data
@@ -53,15 +51,19 @@ px.display(df)
 px live -f my_first_script.pxl
 ```
 
-Use your arrow keys to scroll to the far right of the table and you should see a new columns labeled `pod` and `service`, representing the kubernetes entity that initiated the traced connection. Note that some of the connections in the table are missing context (a `pod` or `service`). This occasionally occurs due to a gap in metadata or a short-lived `upid`.
+> Your CLI output should look similar to the following:
 
 <svg title='Script output in the Live CLI after adding pod and service metadata columns.' src='pxl-scripts/first-script-3.png'/>
 
+> Use your arrow keys to scroll to the far right of the table and you should see a new columns labeled `pod` and `service`, representing the kubernetes entity that initiated the traced connection. Note that some of the connections in the table are missing context (a `pod` or `service`). This occasionally occurs due to a gap in metadata or a short-lived `upid`.
+
 ## Grouping and Aggregating Data
 
-Let's [group](/reference/pxl/operators/group-by/) the connection data by unique pairs of values in the `pod` and `service` columns, computing the aggregating expressions on each group of data.
+Let's [group](/reference/pxl/operators/dataframe.groupby/) the connection data by unique pairs of values in the `pod` and `service` columns, computing the aggregating expressions on each group of data.
 
-*Note that PxL does not currently support standalone groupings, you must always follow the `groupby()` call with a call to `agg()`. However, the agg call can take zero arguments. A full list of the aggregating functions is available [here](/reference/pxl/udf/#aggregate-functions).*
+<Alert variant="outlined" severity="info">
+  PxL does not currently support standalone groupings, you must always follow the `groupby()` call with a call to `agg()`. However, the agg() call can take zero arguments. A full list of the aggregating functions is available <a href="/reference/pxl/udf/#aggregate-functions">here</a>.
+</Alert>
 
 ```python:numbers
 # Import Pixie's module for querying data
@@ -74,29 +76,58 @@ df = px.DataFrame(table='conn_stats', start_time='-30s')
 df.pod = df.ctx['pod']
 df.service = df.ctx['service']
 
-# Group data by unique values in the 'pod' column and calculate the
-# sum of the 'bytes_sent' and 'bytes_recv' for each unique pod grouping.
-df = df.groupby(['pod', 'service']).agg(
-	bytes_sent=('bytes_sent', px.sum),
-	bytes_recv=('bytes_recv', px.sum)
+# Calculate connection stats for each process for each unique pod.
+df = df.groupby(['service', 'pod', 'upid']).agg(
+	# The fields below are counters per UPID, so we take
+	# the min (starting value) and the max (ending value) to subtract them.
+    bytes_sent_min=('bytes_sent', px.min),
+    bytes_sent_max=('bytes_sent', px.max),
+    bytes_recv_min=('bytes_recv', px.min),
+    bytes_recv_max=('bytes_recv', px.max),
 )
 
-# Force ordering of the columns (do not include _clusterID_, which is a product of the CLI and not the PxL script)
-df = df[['service', 'pod', 'bytes_sent', 'bytes_recv']]
+# Calculate connection stats over the time window.
+df.bytes_sent = df.bytes_sent_max - df.bytes_sent_min
+df.bytes_recv = df.bytes_recv_max - df.bytes_recv_min
+
+# Calculate connection stats for each unique pod. Since there
+# may be multiple processes per pod we perform an additional aggregation to
+# consolidate those into one entry.
+df = df.groupby(['service', 'pod']).agg(
+    bytes_sent=('bytes_sent', px.sum),
+    bytes_recv=('bytes_recv', px.sum),
+)
 
 # Display the DataFrame with table formatting
 px.display(df)
 ```
 
+> Pods can have multiple processes, so on `line 12` we [group](/reference/pxl/operators/dataframe.groupby/) our connection stats by unique `service`, `pod` and `upid` pair. Later in the script, we will aggregate the connection stats into a single value per pod.
+
+> The `conn_stats` table [reference docs](/reference/datatables/conn_stats/) show that the `bytes_sent` and `bytes_recv` columns are of type `METRIC_COUNTER`.
+
+<Alert variant="outlined" severity="info">
+  A <b>counter</b> is a cumulative metric that represents a single monotonically increasing counter whose value can only increase or be set to zero on restart. For example, Pixie uses a counter to represent the number of bytes sent to a remote endpoint since the beginning of tracing.
+</Alert>
+<Alert variant="outlined" severity="info">
+  A <b>guage</b> is a metric that represents a single value that can arbitrarily increase or decrease. For example, Pixie uses a guage to represent the number of active connections with a remote endpoint.
+</Alert>
+
+> Since we're interested in knowing the number of bytes sent and received over the last 30 seconds, we calculate the `min` (starting value) and the `max` (ending value) for each unique pod process. On `line 22` we subtract these two values to find the total bytes sent and received over the time window.
+
+> On `line 28`, we group the connection stats for each unique pod, aggregating the values for each pod process.
+
 2. Save your script, exit the Live CLI using `ctrl+c` and re-run the script.
+
+> Your CLI output should look similar to the following:
 
 <svg title='Script output in the Live CLI after grouping and aggregating the data.' src='pxl-scripts/first-script-4.png'/>
 
-Each row in the output represents a unique `pod` and `service` pair that had one or more connections traced in the last 30 seconds. All of the connections between these `pod` / `service` pairs have had their sent- and received- bytes summed for the 30 second time period.
+> Each row in the output represents a unique `pod` and `service` pair that had one or more connections traced in the last 30 seconds. All of the connections between these `pod` / `service` pairs have had their sent- and received- bytes summed for the 30 second time period.
 
 ## Filtering
 
-Let's [filter](/reference/pxl/operators/filter/) out the rows in the DataFrame that do not have a service identified (an empty value for the `service` column).
+Let's [filter](/reference/pxl/operators/dataframe.filter) out the rows in the DataFrame that do not have a service identified (an empty value for the `service` column).
 
 ```python:numbers
 # Import Pixie's module for querying data
@@ -109,15 +140,27 @@ df = px.DataFrame(table='conn_stats', start_time='-30s')
 df.pod = df.ctx['pod']
 df.service = df.ctx['service']
 
-# Group data by unique values in the 'pod' column and calculate the
-# sum of the 'bytes_sent' and 'bytes_recv' for each unique pod grouping.
-df = df.groupby(['pod', 'service']).agg(
-	bytes_sent=('bytes_sent', px.sum),
-	bytes_recv=('bytes_recv', px.sum)
+# Calculate connection stats for each process for each unique pod.
+df = df.groupby(['service', 'pod', 'upid']).agg(
+	# The fields below are counters per UPID, so we take
+	# the min (starting value) and the max (ending value) to subtract them.
+    bytes_sent_min=('bytes_sent', px.min),
+    bytes_sent_max=('bytes_sent', px.max),
+    bytes_recv_min=('bytes_recv', px.min),
+    bytes_recv_max=('bytes_recv', px.max),
 )
 
-# Force ordering of the columns (do not include _clusterID_, which is a product of the CLI and not the PxL script)
-df = df[['service', 'pod', 'bytes_sent', 'bytes_recv']]
+# Calculate connection stats over the time window.
+df.bytes_sent = df.bytes_sent_max - df.bytes_sent_min
+df.bytes_recv = df.bytes_recv_max - df.bytes_recv_min
+
+# Calculate connection stats for each unique pod. Since there
+# may be multiple processes per pod we perform an additional aggregation to
+# consolidate those into one entry.
+df = df.groupby(['service', 'pod']).agg(
+    bytes_sent=('bytes_sent', px.sum),
+    bytes_recv=('bytes_recv', px.sum),
+)
 
 # Filter out connections that don't have their service identified.
 df = df[df.service != '']
@@ -128,13 +171,17 @@ px.display(df)
 
 3. Save your script, exit the Live CLI using `ctrl+c` and re-run the script.
 
-<svg title='Script output in the Live CLI after filtering out rows without a service identified.' src='pxl-scripts/first-script-5.png'/>
+> Your CLI output should look similar to the following. Note that the script output no longer shows rows that are missing a `service` value.
 
-The script output shows that the rows that were missing a `service` value are no longer included in the table.
+<svg title='Script output in the Live CLI after filtering out rows without a service identified.' src='pxl-scripts/first-script-5.png'/>
 
 ## Conclusion
 
-You now have a script that produces a table summarizing the total amount of traffic coming in and out of each of the pods in your cluster for the last 30s (`start_time`). This could be used to:
+Congrats! You have written a script that produces a table summarizing the total amount of traffic coming in and out of each of the pods in your cluster for the last 30 seconds.
+
+This script could be used to:
 
 - Examine the balance of a `pod`'s incoming vs outgoing traffic.
 - Investigate if `pods` under the same `service` receive a similar amount of traffic or if there is an imbalance in traffic received.
+
+In [Tutorial #3](/tutorials/pxl-scripts/write-pxl-scripts/custom-pxl-scripts-3) we will learn how to add more visualizations for this script.

--- a/content/en/04-tutorials/02-pxl-scripts/01-write-pxl-scripts/02-custom-pxl-scripts-2.md
+++ b/content/en/04-tutorials/02-pxl-scripts/01-write-pxl-scripts/02-custom-pxl-scripts-2.md
@@ -183,5 +183,3 @@ This script could be used to:
 
 - Examine the balance of a `pod`'s incoming vs outgoing traffic.
 - Investigate if `pods` under the same `service` receive a similar amount of traffic or if there is an imbalance in traffic received.
-
-In [Tutorial #3](/tutorials/pxl-scripts/write-pxl-scripts/custom-pxl-scripts-3) we will learn how to add more visualizations for this script.


### PR DESCRIPTION
This PxL script tutorial shows how to calculate `bytes_sent` and `bytes_recv` per pod. The existing PxL script failed to account for the fact that the `conn_stats` bytes columns are of type `METRIC_COUNTER`. This update calculates the min / max bytes values and subtracts the two to provide values scoped to the time window. This demo PxL script is now consistent with the logic in `px/outbound_conns`.

Signed-off-by: Hannah Troisi <htroisi@pixielabs.ai>