### PR TITLE
Update Java profiling documentation

### DIFF
--- a/content/en/01-about-pixie/06-troubleshooting.md
+++ b/content/en/01-about-pixie/06-troubleshooting.md
@@ -115,7 +115,7 @@ If specific services / requests are missing, it is possible that your applicatio
 
 ### Why can’t I see application profiles / flamegraphs for my pod / node?
 
-Pixie's [continuous profiler](/tutorials/pixie-101/profiler/) currently supports Go, C++, Rust and Java. Java support is a beta feature and must be [manually enabled](/tutorials/pixie-101/profiler/#prerequisites-enabling-java-support). For best results, run Java applications with `-XX:+PreserveFramePointer`.
+Pixie's [continuous profiler](/tutorials/pixie-101/profiler/) currently supports Go, C++, Rust and Java. For best results, run Java applications with `-XX:+PreserveFramePointer`.
 
 ### Why is the vizier-pem pod’s memory increasing?
 

--- a/content/en/04-tutorials/01-pixie-101/06-profiler.md
+++ b/content/en/04-tutorials/01-pixie-101/06-profiler.md
@@ -9,7 +9,7 @@ redirect_from:
 
 This tutorial will demonstrate how to use Pixie's Always-On Profiling feature to investigate a spike in CPU utilization, using a flamegraph to identify a performance issue within the application code.
 
-Pixie's continuous profiler currently supports Go, C++, and Rust. Java support is a beta feature and must be [manually enabled](#prerequisites-enabling-java-support). Other language support coming soon.
+Pixie's continuous profiler currently supports Go, C++, Rust and Java. For best results, run Java applications with `-XX:+PreserveFramePointer`. Other language support coming soon.
 
 <YouTube youTubeId="Zr-s3EvAey8"/>
 
@@ -19,7 +19,7 @@ You will need a Kubernetes cluster with Pixie installed. If you do not have a cl
 
 ### Java Support
 
-Support for Java profiling is included by default in Pixie. 
+Support for Java profiling is included by default in Pixie.
 
 For best results, run Java applications with `-XX:+PreserveFramePointer`.
 

--- a/content/en/04-tutorials/01-pixie-101/06-profiler.md
+++ b/content/en/04-tutorials/01-pixie-101/06-profiler.md
@@ -17,25 +17,9 @@ Pixie's continuous profiler currently supports Go, C++, and Rust. Java support i
 
 You will need a Kubernetes cluster with Pixie installed. If you do not have a cluster, you can create a minikube cluster and install Pixie using one of our [install guides](/installing-pixie/install-guides/).
 
-### Enabling Java Support
+### Java Support
 
-Java support is a beta feature available in Pixie vizier version 0.10.22+, and must be manually enabled during the deployment of Pixie.
-
-<Alert variant="outlined" severity="info">
-  Instructions for identifying and updating your Pixie vizier version can be found <a href="/reference/admin/updating-pixie/#updating-pixie-cloud-and-vizier">here</a>.
-</Alert>
-
-To enable Java support when deploying Pixie with the [Pixie CLI](/installing-pixie/install-schemes/cli/), run:
-
-```bash
-px deploy --pem_flags=PL_PROFILER_JAVA_SYMBOLS=1
-```
-
-To enable Java support when deploying Pixie with [Helm](/installing-pixie/install-schemes/helm/), run:
-
-```bash
-helm install pixie pixie-operator/pixie-operator-chart --set deployKey=<deploy-key-goes-here> --set clusterName=<cluster-name> --namespace pl --create-namespace --set dataCollectorParams.customPEMFlags.PL_PROFILER_JAVA_SYMBOLS=true
-```
+Support for Java profiling is included by default in Pixie. 
 
 For best results, run Java applications with `-XX:+PreserveFramePointer`.
 


### PR DESCRIPTION
Java profiling is enabled by default now. Update the documentation to reflect this.

Signed-off-by: Omid Azizi <oazizi@pixielabs.ai>