### PR TITLE
Add documentation explaining the Vizier --use_etcd_operator flag

### DIFF
--- a/content/en/02-installing-pixie/02-setting-up-k8s/02-eks-setup.md
+++ b/content/en/02-installing-pixie/02-setting-up-k8s/02-eks-setup.md
@@ -44,6 +44,12 @@ kubectl get svc
 
 You can deploy clusters with alternate configurations or by using the AWS console. You can view our [requirements](/installing-pixie/requirements) to determine recommended node level compute requirements.
 
+### Verify whether your cluster has a storage class
+
+If you want to use the default settings for installing Pixie's Vizier module, you'll want to ensure that your EKS cluster has [persistent volume and storage classes](https://docs.aws.amazon.com/eks/latest/userguide/storage-classes.html) set up.
+
+If your cluster does not have an accessible storage class type, you'll want to deploy with the [etcd operator](/reference/admin/deploy-options/#select-metadata-storage-option). Note that self-hosted Pixie Cloud requires persistent volumes.
+
 ## Deploy Pixie
 
 Once connected, follow the [install steps](/installing-pixie/install-guides) to deploy Pixie.

--- a/content/en/05-reference/01-admin/04-deploy-options.md
+++ b/content/en/05-reference/01-admin/04-deploy-options.md
@@ -15,6 +15,7 @@ Pixie offers the following deploy options:
 - [Provide a custom cluster name](#providing-a-custom-cluster-name)
 - [Configure Pixie's memory usage](#configure-pixie-memory-usage)
 - [Set the data access mode](#setting-the-data-access-mode)
+- [Select metadata storage option](#select-metadata-storage-option)
 
 To see the full set of deploy options, install the [Pixie CLI](/installing-pixie/install-schemes/cli/) and run `px deploy --help`.
 
@@ -177,3 +178,21 @@ helm install pixie pixie-operator/pixie-operator-chart --set deployKey=<deploy-k
 ```
 
 You may also directly update the `dataAccess` field in your `values.yaml` file.
+
+## Select metadata storage option
+
+By default, Pixie uses a persistent volume to store 24 hours' worth of Kubernetes metadata updates.
+
+For clusters that don't support persistent volumes, we have an alternative mode that uses the etcd operator.
+
+To deploy using the etcd operator using `px deploy`, use the `--use_etcd_operator` flag.
+
+```bash
+px deploy --use_etcd_operator
+```
+
+To deploy with Helm using the etcd operator, use the `--useEtcdOperator` flag.
+
+```bash
+helm install pixie pixie-operator/pixie-operator-chart --set deployKey=<deploy-key-goes-here> --namespace pl --create-namespace --set pixie-chart.useEtcdOperator=true
+```


### PR DESCRIPTION
Some users have run into issues deploying the Vizier module without persistent volume support on their cluster, especially on EKS clusters. This diff adds the use_etcd_operator flag to the documentation so that users can discover that option for clusters that don't have persistent volume support.