### PR TITLE
Add page clarifying that Pixie supports environments beyond those in "Setting up Kubernetes"

### DIFF
--- a/content/en/02-installing-pixie/02-setting-up-k8s/06-other-environments.md
+++ b/content/en/02-installing-pixie/02-setting-up-k8s/06-other-environments.md
@@ -1,0 +1,12 @@
+---
+title: "Additional environments"
+metaTitle: "Install | Install Guides | AKS"
+metaDescription: "Pixie on other environments"
+order: 6
+redirect_from:
+    - /installing-pixie/install-guides/other-environments/
+---
+
+Pixie supports additional environments beyond those listed in this section.
+
+Check out the [requirements](/installing-pixie/requirements) page for the list of supported Kubernetes environments.

--- a/content/en/02-installing-pixie/02-setting-up-k8s/index.md
+++ b/content/en/02-installing-pixie/02-setting-up-k8s/index.md
@@ -16,3 +16,4 @@ If you already have a Kubernetes environment, you can skip these steps. If you a
 - [Managed - EKS](/installing-pixie/setting-up-k8s/eks-setup)
 - [Managed - GKE](/installing-pixie/setting-up-k8s/gke-setup)
 - [Managed - AKS](/installing-pixie/setting-up-k8s/aks-setup)
+- [Other environments](/installing-pixie/setting-up-k8s/other-environments)


### PR DESCRIPTION
When perusing our docs, it is a bit confusing how Setting up Kubernetes lists a subset of the environments that Pixie actually supports. To reduce confusion (users have mistakenly thought that those were the only supported environments), I've added a page clarifying that those are not the only environments that Pixie can run on. This information was already present, but adding it to the sidebar will make it even more visible.

Signed-off-by: Natalie Serrino <nserrino@pixielabs.ai>