### PR TITLE
Update self hosted cloud docs to use a specific release

### DIFF
--- a/content/en/02-installing-pixie/03-install-guides/02-self-hosted-pixie.md
+++ b/content/en/02-installing-pixie/03-install-guides/02-self-hosted-pixie.md
@@ -34,6 +34,24 @@ Get Pixie fully managed with [Pixie Community Cloud](/installing-pixie/install-g
     cd pixie
     ```
 
+1. Pick a cloud release version from the [tags](https://github.com/pixie-io/pixie/tags) on the repo. The following should pick the latest release for you.
+
+    ```bash
+    export LATEST_CLOUD_RELEASE=$(git tag | grep 'release/cloud'  | sort -r | head -n 1 | awk -F/ '{print $NF}')
+    ```
+
+1. Checkout the release tag.
+
+    ```bash
+    git checkout "release/cloud/prod/${LATEST_CLOUD_RELEASE}"
+    ```
+
+1. Update the versions in the appropriate kustomization file.
+
+    ```bash
+    perl -pi -e "s|newTag: latest|newTag: \"${LATEST_CLOUD_RELEASE}\"|g" k8s/cloud/public/kustomization.yaml
+    ```
+
 1. (Optional) By default, the self-hosted Pixie Cloud will be accessible through `dev.withpixie.dev`. If you wish to use a custom domain name, replace all occurances of `dev.withpixie.dev` in the following files with the domain name of your choice.
 
     ```bash
@@ -77,7 +95,7 @@ Get Pixie fully managed with [Pixie Community Cloud](/installing-pixie/install-g
     kustomize build k8s/cloud/public/ | kubectl apply -f -
     ```
 
-10. Wait for all pods within the `plc` namespace to become ready and available. Note that you may have one or more `create-hydra-client-job` pod errors, but as long as long as another instance of that pod successfully completes, that is ok.
+1. Wait for all pods within the `plc` namespace to become ready and available. Note that you may have one or more `create-hydra-client-job` pod errors, but as long as long as another instance of that pod successfully completes, that is ok.
 
     ```bash
     kubectl get pods -n plc


### PR DESCRIPTION
Deploying self hosted cloud from main can be error prone since configs might
get updated on main but might not be valid until a cloud release is done.

Deploying with the latest image tags might also cause issues since it's easy
for the cluster to end up with out of sync services when a pod restarts and a
newer image is pulled for only a subset of the services.

This fixes both problems by instructing users to select a version and deploy
with scripts and configs pinned to that version.

Signed-off-by: Vihang Mehta <vihang@pixielabs.ai>
