### PR TITLE
Update protocols list: AMQP is no longer beta

### DIFF
--- a/content/en/01-about-pixie/02-data-sources.md
+++ b/content/en/01-about-pixie/02-data-sources.md
@@ -42,7 +42,7 @@ Pixie automatically traces the following protocols:
 | Cassandra     | Supported           |                                |
 | Redis         | Supported           |                                |
 | Kafka         | Supported           |                                |
-| AMQP          | Beta Feature        | Must be [manually enabled](/reference/admin/deploy-options#set-a-pem-flag) during deployment using the `STIRLING_ENABLE_AMQP_TRACING` PEM flag. |
+| AMQP          | Supported           |                                |
 
 Additional protocols are under development.
 


### PR DESCRIPTION
Update the protocols list to reflect the latest state of AMQP.

Signed-off-by: Omid Azizi <oazizi@pixielabs.ai>