### PR TITLE
Fix image path for custom OLM images

### DIFF
--- a/content/en/05-reference/01-admin/04-deploy-options.md
+++ b/content/en/05-reference/01-admin/04-deploy-options.md
@@ -258,7 +258,7 @@ opm index export --index gcr.io/pixie-oss/pixie-prod/operator/bundle_index:0.0.1
 opm alpha bundle generate --package pixie-operator --channels stable --default stable --directory downloaded/pixie-operator/<version>
 docker build -t ${registry}/bundle:<version> -f bundle.Dockerfile .
 docker push ${registry}/bundle:<version>
-opm index add --bundles ${registry}/bundle:<version> --tag ${registry}/pixie-oss-pixie-prod-operator-bundle_index:0.0.1 -u docker
+opm index add --bundles ${registry}/bundle:<version> --tag ${registry}/gcr.io-pixie-oss-pixie-prod-operator-bundle_index:0.0.1 -u docker
 docker push ${registry}/pixie-oss-pixie-prod-operator-bundle_index:0.0.1
 ```
 


### PR DESCRIPTION
The instructions were missing a small part in the registry path. This change adds it in.

Signed-off-by: Michelle Nguyen <michellenguyen@pixielabs.ai>