### PR TITLE
[self-hosted] Update install guide for semantically versioned cloud

### DIFF
--- a/content/en/02-installing-pixie/03-install-guides/02-self-hosted-pixie.md
+++ b/content/en/02-installing-pixie/03-install-guides/02-self-hosted-pixie.md
@@ -37,13 +37,13 @@ Get Pixie fully managed with [Pixie Community Cloud](/installing-pixie/install-g
 1. Pick a cloud release version from the [tags](https://github.com/pixie-io/pixie/tags) on the repo. The following should pick the latest release for you.
 
     ```bash
-    export LATEST_CLOUD_RELEASE=$(git tag | grep 'release/cloud'  | sort -r | head -n 1 | awk -F/ '{print $NF}')
+    export LATEST_CLOUD_RELEASE=$(git tag | grep -Po '(?<=release/cloud/v)[^\-]*$' | sort -t '.' -k1,1nr -k2,2nr -k3,3nr | head -n 1)
     ```
 
 1. Checkout the release tag.
 
     ```bash
-    git checkout "release/cloud/prod/${LATEST_CLOUD_RELEASE}"
+    git checkout "release/cloud/v${LATEST_CLOUD_RELEASE}"
     ```
 
 1. Update the versions in the appropriate kustomization file.


### PR DESCRIPTION
Summary: Updates commands in the self-hosted install guide to work with semantically versioned cloud. This PR shouldn't be landed until the semantically versioned cloud PR lands on the main Pixie side.

Type of change: /kind cleanup.

Test Plan: Tested that the new `LATEST_CLOUD_RELEASE` command works by adding a bunch of fake tags in the repo and seeing that they were sorted correctly and the correct latest tag was found.
