### PR TITLE
Update data source docs to include OpenSSL v3 tracing support

### DIFF
--- a/content/en/01-about-pixie/02-data-sources.md
+++ b/content/en/01-about-pixie/02-data-sources.md
@@ -56,5 +56,5 @@ Pixie supports tracing of traffic encrypted with the following libraries:
 
 | Library                                      | Notes                                       |
 | :------------------------------------------- | :------------------------------------------ |
-| [OpenSSL](https://www.openssl.org/)          | Version 1.1.0 or 1.1.1, dynamically linked. |
+| [OpenSSL](https://www.openssl.org/)          | Version 1.1.0, 1.1.1 or 3.x dynamically linked. |
 | [Go TLS](https://golang.org/pkg/crypto/tls/) | Requires a build with [debug information](/reference/admin/debug-info).                |


### PR DESCRIPTION
https://github.com/pixie-io/pixie/pull/1337 will enable Pixie to trace OpenSSL v3 applications. Let's update the docs in line with the release set for this week. Our new style of TLS tracing requires less maintenance and as a result future releases of OpenSSL will be supported without changes on our end.