### PR TITLE
Mark ARM as supported in requirements

### DIFF
--- a/content/en/02-installing-pixie/01-requirements.md
+++ b/content/en/02-installing-pixie/01-requirements.md
@@ -85,7 +85,7 @@ Pixie requires an `x86-64` architecture.
 |         | Support           |
 | :------ | :---------------- |
 | x86-64  | Supported         |
-| ARM     | Not Supported     |
+| ARM     | Supported         |
 
 ## Memory
 


### PR DESCRIPTION
There is one, small remaining piece to calling ARM complete (OLM), but the rest of Pixie works on ARM.
We can choose to merge this in after that is complete, but wanted to make sure we didn't forget to update the docs.