### PR TITLE
Update encryption library data sources to include support for boringcrypto

### DIFF
--- a/content/en/01-about-pixie/02-data-sources.md
+++ b/content/en/01-about-pixie/02-data-sources.md
@@ -57,4 +57,4 @@ Pixie supports tracing of traffic encrypted with the following libraries:
 | Library                                      | Notes                                       |
 | :------------------------------------------- | :------------------------------------------ |
 | [OpenSSL](https://www.openssl.org/)          | Version 1.1.0, 1.1.1 or 3.x dynamically linked. |
-| [Go TLS](https://golang.org/pkg/crypto/tls/) | Requires a build with [debug information](/reference/admin/debug-info).                |
+| [Go TLS](https://golang.org/pkg/crypto/tls/) -- standard and [boringcrypto](https://pkg.go.dev/crypto/internal/boring) | Requires a build with [debug information](/reference/admin/debug-info).                |


### PR DESCRIPTION
Our Go tls tracing is flexible enough that it instruments Golang's standard crypto and boringcrypto implementations. We should document that this is supported since it was reported as a gap in our feature set (https://github.com/pixie-io/pixie/issues/597).

## Testing done
- [x] Ran the website locally to verify that the long line is rendered nicely
<img width="1346" alt="Screenshot 2023-06-08 at 1 42 57 PM" src="https://github.com/pixie-io/docs.px.dev/assets/5855593/3d3762c5-6222-46b9-92ba-5a85cc1f5d36">
