### PR TITLE
Use perl instead of grep since macOS grep flags are different

### DIFF
--- a/content/en/02-installing-pixie/03-install-guides/02-self-hosted-pixie.md
+++ b/content/en/02-installing-pixie/03-install-guides/02-self-hosted-pixie.md
@@ -37,7 +37,7 @@ Get Pixie fully managed with [Pixie Community Cloud](/installing-pixie/install-g
 1. Pick a cloud release version from the [tags](https://github.com/pixie-io/pixie/tags) on the repo. The following should pick the latest release for you.
 
     ```bash
-    export LATEST_CLOUD_RELEASE=$(git tag | grep -Po '(?<=release/cloud/v)[^\-]*$' | sort -t '.' -k1,1nr -k2,2nr -k3,3nr | head -n 1)
+    export LATEST_CLOUD_RELEASE=$(git tag | perl -ne 'print $1 if /release\/cloud\/v([^\-]*)$/' | sort -t '.' -k1,1nr -k2,2nr -k3,3nr | head -n 1)
     ```
 
 1. Checkout the release tag.


### PR DESCRIPTION
This command uses perl and should work on both linux and macOS systems.
Fixes pixie-io/pixie#1651

Signed-off-by: Vihang Mehta <vihang@pixielabs.ai>
