### PR TITLE
Update data source docs to include BoringSSL support

### DIFF
--- a/content/en/01-about-pixie/02-data-sources.md
+++ b/content/en/01-about-pixie/02-data-sources.md
@@ -58,3 +58,4 @@ Pixie supports tracing of traffic encrypted with the following libraries:
 | :------------------------------------------- | :------------------------------------------ |
 | [OpenSSL](https://www.openssl.org/)          | Version 1.1.0, 1.1.1 or 3.x dynamically linked. |
 | [Go TLS](https://golang.org/pkg/crypto/tls/) -- standard and [boringcrypto](https://pkg.go.dev/crypto/internal/boring) | Requires a build with [debug information](/reference/admin/debug-info).                |
+| [BoringSSL](https://github.com/google/boringssl) | |


### PR DESCRIPTION
This PR updates the data source docs to include BoringSSL support. https://github.com/pixie-io/pixie/pull/1678 is the last change we intend to make before calling the project complete.