### PR TITLE
Update `px/tcp_drops` and `px/tcp_retransmits` to `bpftrace/`

### DIFF
--- a/content/en/04-tutorials/01-pixie-101/01-network-monitoring.md
+++ b/content/en/04-tutorials/01-pixie-101/01-network-monitoring.md
@@ -162,4 +162,4 @@ for a different view of the graph.
 This tutorial demonstrated three of Pixie's [community scripts](https://github.com/pixie-io/pixie/tree/main/src/pxl_scripts). For more insight into your network, check out the following scripts:
 
 - [`px/dns_data`](https://work.withpixie.ai/script/dns_data) shows the most recent DNS requests in your cluster, including the full request and response bodies.
-- [`bpftrace/tcp_retransmits`](https://work.withpixie.ai/script/tcp_retransmits) graphs the TCP retransmission counts across your cluster. Don't forget to click the RUN button.
+- [`bpftrace/tcp_retransmits`](https://work.withpixie.ai/script/bpftrace/tcp_retransmits) graphs the TCP retransmission counts across your cluster. Don't forget to click the RUN button.

--- a/content/en/04-tutorials/01-pixie-101/01-network-monitoring.md
+++ b/content/en/04-tutorials/01-pixie-101/01-network-monitoring.md
@@ -133,9 +133,9 @@ to sort the column data.
 
 TCP drops and retransmits can indicate network connectivity issues that may affect application performance.
 
-Let's use the `px/tcp_drops`script to see a global view of TCP drops across the cluster.
+Let's use the `bpftrace/tcp_drops`script to see a global view of TCP drops across the cluster.
 
-1. Select `px/tcp_drops` from the script drop-down menu.
+1. Select `bpftrace/tcp_drops` from the script drop-down menu.
 
 <Alert variant="outlined" severity="info">
   This script is a PxL mutation script. While the previous scripts query the Pixie platform for data, this script extends Pixie to collect new data. Mutation scripts must be run manually; they do not automatically run when they are first opened.
@@ -162,4 +162,4 @@ for a different view of the graph.
 This tutorial demonstrated three of Pixie's [community scripts](https://github.com/pixie-io/pixie/tree/main/src/pxl_scripts). For more insight into your network, check out the following scripts:
 
 - [`px/dns_data`](https://work.withpixie.ai/script/dns_data) shows the most recent DNS requests in your cluster, including the full request and response bodies.
-- [`px/tcp_retransmits`](https://work.withpixie.ai/script/tcp_retransmits) graphs the TCP retransmission counts across your cluster. Don't forget to click the RUN button.
+- [`bpftrace/tcp_retransmits`](https://work.withpixie.ai/script/tcp_retransmits) graphs the TCP retransmission counts across your cluster. Don't forget to click the RUN button.

--- a/content/en/04-tutorials/04-custom-data/01-distributed-bpftrace-deployment.md
+++ b/content/en/04-tutorials/04-custom-data/01-distributed-bpftrace-deployment.md
@@ -54,10 +54,10 @@ In this demo, we'll deploy Dale Hamel's bpftrace [TCP retransmit tool](https://g
 
 ### Running the PxL Script in the Live UI
 
-We've incorporated this trace into a PxL script called [`px/tcp_retransmits`](https://github.com/pixie-io/pixie/tree/main/src/pxl_scripts/px/tcp_retransmits). To run this script:
+We've incorporated this trace into a PxL script called [`bpftrace/tcp_retransmits`](https://github.com/pixie-io/pixie/tree/main/src/pxl_scripts/bpftrace/tcp_retransmits). To run this script:
 
 - Open up Pixie's [Live View](https://work.withpixie.ai) and select your cluster.
-- Select the `px/tcp_retransmits` script using the drop down `script` menu or with Pixie Command. Pixie Command can be opened with the `ctrl/cmd+k` keyboard shortcut.
+- Select the `bpftrace/tcp_retransmits` script using the drop down `script` menu or with Pixie Command. Pixie Command can be opened with the `ctrl/cmd+k` keyboard shortcut.
 - Run the script using the Run button in the top right, or with the `ctrl/cmd+enter` keyboard shortcut.
 
 Once the probe is deployed to all the nodes in the cluster, the probes will begin to push out data into tables. The PxL script queries this data and the Vis Spec defines how this data will be displayed.


### PR DESCRIPTION
Summary: Updates documentation to reflect updated location of the pxl scripts `tcp_drops` and `tcp_retransmits`

Related issues/PRs: https://github.com/pixie-io/pixie/pull/1717 https://github.com/pixie-io/pixie/pull/1688