### PR TITLE
Update install scheme pages to reflect selected Cloud URL

### DIFF
--- a/content/en/02-installing-pixie/03-install-guides/01-hosted-pixie/01-cosmic-cloud.md
+++ b/content/en/02-installing-pixie/03-install-guides/01-hosted-pixie/01-cosmic-cloud.md
@@ -47,8 +47,8 @@ To deploy Pixie using the CLI:
 </Alert>
 
 ```bash
-# PL_CLOUD_ADDR must be set before any pixie cli commands are run!
-export PL_CLOUD_ADDR=getcosmic.ai
+# PX_CLOUD_ADDR must be set before any pixie cli commands are run!
+export PX_CLOUD_ADDR=getcosmic.ai
 
 # List Pixie deployment options.
 px deploy --help

--- a/content/en/02-installing-pixie/03-install-guides/02-self-hosted-pixie/index.md
+++ b/content/en/02-installing-pixie/03-install-guides/02-self-hosted-pixie/index.md
@@ -146,7 +146,7 @@ Add users to your organization to share access to Pixie Live Views, query runnin
 1. Set the cloud address with an environment variable. If you configured a custom domain name, use that as the variable's value:
 
     ```bash
-    export PL_CLOUD_ADDR=dev.withpixie.dev
+    export PX_CLOUD_ADDR=dev.withpixie.dev
     ```
 
 1. Install Pixie's CLI. The easiest way to install Pixie's CLI is using the install script:

--- a/content/en/02-installing-pixie/04-install-schemes/01-cli.md
+++ b/content/en/02-installing-pixie/04-install-schemes/01-cli.md
@@ -103,8 +103,21 @@ rpm -i pixie-px.x86_64.rpm
   Please refer to <a href="/reference/admin/environment-configs">Environment-Specific Configurations</a> for other configurations that should be set for your specific Kubernetes environment.
 </Alert>
 
-<CliDeployInstructions />
-
+<TemplatedCodeBlock
+  code={`
+# List Pixie deployment options.
+px deploy --help \n
+# Deploy the Pixie Platform in your K8s cluster (No OLM present on cluster).
+export PL_CLOUD_ADDR=@@
+px deploy \n
+# Deploy the Pixie Platform in your K8s cluster (OLM already exists on cluster).
+export PL_CLOUD_ADDR=@@
+px deploy --deploy_olm=false \n
+# Deploy Pixie with a specific memory limit (2Gi is the default, 1Gi is the minimum recommended)
+export PL_CLOUD_ADDR=@@
+px deploy --pem_memory_limit=1Gi
+  `}
+/>
 
 Pixie will deploy pods to the `pl`, `px-operator`, and `olm`(if deploying the OLM) namespaces.
 

--- a/content/en/02-installing-pixie/04-install-schemes/01-cli.md
+++ b/content/en/02-installing-pixie/04-install-schemes/01-cli.md
@@ -108,13 +108,13 @@ rpm -i pixie-px.x86_64.rpm
 # List Pixie deployment options.
 px deploy --help \n
 # Deploy the Pixie Platform in your K8s cluster (No OLM present on cluster).
-export PX_CLOUD_ADDR=@@
+export PX_CLOUD_ADDR=@PLACEHOLDER@
 px deploy \n
 # Deploy the Pixie Platform in your K8s cluster (OLM already exists on cluster).
-export PX_CLOUD_ADDR=@@
+export PX_CLOUD_ADDR=@PLACEHOLDER@
 px deploy --deploy_olm=false \n
 # Deploy Pixie with a specific memory limit (2Gi is the default, 1Gi is the minimum recommended)
-export PX_CLOUD_ADDR=@@
+export PX_CLOUD_ADDR=@PLACEHOLDER@
 px deploy --pem_memory_limit=1Gi
   `}
 />

--- a/content/en/02-installing-pixie/04-install-schemes/01-cli.md
+++ b/content/en/02-installing-pixie/04-install-schemes/01-cli.md
@@ -108,13 +108,13 @@ rpm -i pixie-px.x86_64.rpm
 # List Pixie deployment options.
 px deploy --help \n
 # Deploy the Pixie Platform in your K8s cluster (No OLM present on cluster).
-export PL_CLOUD_ADDR=@@
+export PX_CLOUD_ADDR=@@
 px deploy \n
 # Deploy the Pixie Platform in your K8s cluster (OLM already exists on cluster).
-export PL_CLOUD_ADDR=@@
+export PX_CLOUD_ADDR=@@
 px deploy --deploy_olm=false \n
 # Deploy Pixie with a specific memory limit (2Gi is the default, 1Gi is the minimum recommended)
-export PL_CLOUD_ADDR=@@
+export PX_CLOUD_ADDR=@@
 px deploy --pem_memory_limit=1Gi
   `}
 />

--- a/content/en/02-installing-pixie/04-install-schemes/01-cli.md
+++ b/content/en/02-installing-pixie/04-install-schemes/01-cli.md
@@ -103,22 +103,8 @@ rpm -i pixie-px.x86_64.rpm
   Please refer to <a href="/reference/admin/environment-configs">Environment-Specific Configurations</a> for other configurations that should be set for your specific Kubernetes environment.
 </Alert>
 
-```bash
-# List Pixie deployment options.
-px deploy --help
+<CliDeployInstructions />
 
-# Deploy the Pixie Platform in your K8s cluster (No OLM present on cluster).
-export PL_CLOUD_ADDR=<getcosmic.ai or withpixie.ai>
-px deploy
-
-# Deploy the Pixie Platform in your K8s cluster (OLM already exists on cluster).
-export PL_CLOUD_ADDR=<getcosmic.ai or withpixie.ai>
-px deploy --deploy_olm=false
-
-# Deploy Pixie with a specific memory limit (2Gi is the default, 1Gi is the minimum recommended)
-export PL_CLOUD_ADDR=<getcosmic.ai or withpixie.ai>
-px deploy --pem_memory_limit=1Gi
-```
 
 Pixie will deploy pods to the `pl`, `px-operator`, and `olm`(if deploying the OLM) namespaces.
 

--- a/content/en/02-installing-pixie/04-install-schemes/02-yaml.md
+++ b/content/en/02-installing-pixie/04-install-schemes/02-yaml.md
@@ -57,7 +57,6 @@ px deploy --extract_yaml ./ --deploy_key <PIXIE_DEPLOYMENT_KEY> \n
 export PX_CLOUD_ADDR=@PLACEHOLDER@
 px deploy --extract_yaml ./ --deploy_key <PIXIE_DEPLOYMENT_KEY> --deploy_olm=false \n
 # Extract YAML (Self-hosting Pixie Cloud).
-export PX_CLOUD_ADDR=@PLACEHOLDER@
 px deploy --extract_yaml ./ --deploy_key <PIXIE_DEPLOYMENT_KEY> --dev_cloud_namespace plc \n
 # Extract YAML (configure Pixie with a specific memory limit - 2Gi is the default, 1Gi is the minimum recommended)
 export PX_CLOUD_ADDR=@PLACEHOLDER@

--- a/content/en/02-installing-pixie/04-install-schemes/02-yaml.md
+++ b/content/en/02-installing-pixie/04-install-schemes/02-yaml.md
@@ -21,7 +21,7 @@ Check if your K8s cluster meets Pixie's [requirements](/installing-pixie/require
 
 <TemplatedCodeBlock
   code={`
-export PL_CLOUD_ADDR=@@
+export PX_CLOUD_ADDR=@@
 px deploy --check_only
   `}
 />
@@ -51,16 +51,16 @@ Run the following CLI command to extract Pixie's manifest files:
 <TemplatedCodeBlock
   code={`
 # Extract YAML (No OLM present on cluster).
-export PL_CLOUD_ADDR=@@
+export PX_CLOUD_ADDR=@@
 px deploy --extract_yaml ./ --deploy_key <PIXIE_DEPLOYMENT_KEY> \n
 # Extract YAML (OLM already exists on cluster).
-export PL_CLOUD_ADDR=@@
+export PX_CLOUD_ADDR=@@
 px deploy --extract_yaml ./ --deploy_key <PIXIE_DEPLOYMENT_KEY> --deploy_olm=false \n
 # Extract YAML (Self-hosting Pixie Cloud).
-export PL_CLOUD_ADDR=@@
+export PX_CLOUD_ADDR=@@
 px deploy --extract_yaml ./ --deploy_key <PIXIE_DEPLOYMENT_KEY> --dev_cloud_namespace plc \n
 # Extract YAML (configure Pixie with a specific memory limit - 2Gi is the default, 1Gi is the minimum recommended)
-export PL_CLOUD_ADDR=@@
+export PX_CLOUD_ADDR=@@
 px deploy --extract_yaml ./ --deploy_key <PIXIE_DEPLOYMENT_KEY> --pem_memory_limit=1Gi
   `}
 />
@@ -92,7 +92,7 @@ To verify that Pixie is running in your environment you can check the <CloudLink
 # Check pods are up
 kubectl get pods -n pl \n
 # Check Pixie Platform and PEM status
-export PL_CLOUD_ADDR=@@
+export PX_CLOUD_ADDR=@@
 px get viziers
 px get pems
   `}

--- a/content/en/02-installing-pixie/04-install-schemes/02-yaml.md
+++ b/content/en/02-installing-pixie/04-install-schemes/02-yaml.md
@@ -19,9 +19,12 @@ The CLI is used to get Pixie's YAML files. You can install the Pixie CLI followi
 
 Check if your K8s cluster meets Pixie's [requirements](/installing-pixie/requirements) by running:
 
-```bash
+<TemplatedCodeBlock
+  code={`
+export PL_CLOUD_ADDR=@@
 px deploy --check_only
-```
+  `}
+/>
 
 If your cluster fails any checks, you may still proceed with installation, but it is unlikely that Pixie will work on your cluster.
 
@@ -45,20 +48,22 @@ Run the following CLI command to extract Pixie's manifest files:
   Please refer to <a href="/reference/admin/environment-configs">Environment-Specific Configurations</a> for other configurations that should be set for your specific Kubernetes environment.
 </Alert>
 
-```bash
+<TemplatedCodeBlock
+  code={`
 # Extract YAML (No OLM present on cluster).
-px deploy --extract_yaml ./ --deploy_key <PIXIE_DEPLOYMENT_KEY>
-
+export PL_CLOUD_ADDR=@@
+px deploy --extract_yaml ./ --deploy_key <PIXIE_DEPLOYMENT_KEY> \n
 # Extract YAML (OLM already exists on cluster).
-px deploy --extract_yaml ./ --deploy_key <PIXIE_DEPLOYMENT_KEY> --deploy_olm=false
-
+export PL_CLOUD_ADDR=@@
+px deploy --extract_yaml ./ --deploy_key <PIXIE_DEPLOYMENT_KEY> --deploy_olm=false \n
 # Extract YAML (Self-hosting Pixie Cloud).
-px deploy --extract_yaml ./ --deploy_key <PIXIE_DEPLOYMENT_KEY> --dev_cloud_namespace plc
-
+export PL_CLOUD_ADDR=@@
+px deploy --extract_yaml ./ --deploy_key <PIXIE_DEPLOYMENT_KEY> --dev_cloud_namespace plc \n
 # Extract YAML (configure Pixie with a specific memory limit - 2Gi is the default, 1Gi is the minimum recommended)
+export PL_CLOUD_ADDR=@@
 px deploy --extract_yaml ./ --deploy_key <PIXIE_DEPLOYMENT_KEY> --pem_memory_limit=1Gi
-
-```
+  `}
+/>
 
 **Note:** The extracted YAMls does not include manifests for each sub-component of Pixie. It includes manifests for etcd, NATS and the cloud-connector service which downloads the manifests for the necessary services and daemonsets.
 
@@ -82,13 +87,13 @@ For more deploy options that you can specify to configure Pixie, refer to our [d
 
 To verify that Pixie is running in your environment you can check the <CloudLink url="/admin">admin page</CloudLink> or run:
 
-```bash
+<TemplatedCodeBlock
+  code={`
 # Check pods are up
-kubectl get pods -n pl
-
-# Check Pixie Platform status
+kubectl get pods -n pl \n
+# Check Pixie Platform and PEM status
+export PL_CLOUD_ADDR=@@
 px get viziers
-
-# Check PEM stats
 px get pems
-```
+  `}
+/>

--- a/content/en/02-installing-pixie/04-install-schemes/02-yaml.md
+++ b/content/en/02-installing-pixie/04-install-schemes/02-yaml.md
@@ -21,7 +21,7 @@ Check if your K8s cluster meets Pixie's [requirements](/installing-pixie/require
 
 <TemplatedCodeBlock
   code={`
-export PX_CLOUD_ADDR=@@
+export PX_CLOUD_ADDR=@PLACEHOLDER@
 px deploy --check_only
   `}
 />
@@ -51,16 +51,16 @@ Run the following CLI command to extract Pixie's manifest files:
 <TemplatedCodeBlock
   code={`
 # Extract YAML (No OLM present on cluster).
-export PX_CLOUD_ADDR=@@
+export PX_CLOUD_ADDR=@PLACEHOLDER@
 px deploy --extract_yaml ./ --deploy_key <PIXIE_DEPLOYMENT_KEY> \n
 # Extract YAML (OLM already exists on cluster).
-export PX_CLOUD_ADDR=@@
+export PX_CLOUD_ADDR=@PLACEHOLDER@
 px deploy --extract_yaml ./ --deploy_key <PIXIE_DEPLOYMENT_KEY> --deploy_olm=false \n
 # Extract YAML (Self-hosting Pixie Cloud).
-export PX_CLOUD_ADDR=@@
+export PX_CLOUD_ADDR=@PLACEHOLDER@
 px deploy --extract_yaml ./ --deploy_key <PIXIE_DEPLOYMENT_KEY> --dev_cloud_namespace plc \n
 # Extract YAML (configure Pixie with a specific memory limit - 2Gi is the default, 1Gi is the minimum recommended)
-export PX_CLOUD_ADDR=@@
+export PX_CLOUD_ADDR=@PLACEHOLDER@
 px deploy --extract_yaml ./ --deploy_key <PIXIE_DEPLOYMENT_KEY> --pem_memory_limit=1Gi
   `}
 />
@@ -92,7 +92,7 @@ To verify that Pixie is running in your environment you can check the <CloudLink
 # Check pods are up
 kubectl get pods -n pl \n
 # Check Pixie Platform and PEM status
-export PX_CLOUD_ADDR=@@
+export PX_CLOUD_ADDR=@PLACEHOLDER@
 px get viziers
 px get pems
   `}

--- a/content/en/02-installing-pixie/04-install-schemes/03-helm.md
+++ b/content/en/02-installing-pixie/04-install-schemes/03-helm.md
@@ -23,7 +23,7 @@ Check if your K8s cluster meets Pixie's [requirements](/installing-pixie/require
 
 <TemplatedCodeBlock
   code={`
-export PL_CLOUD_ADDR=@@
+export PX_CLOUD_ADDR=@@
 px deploy --check_only
   `}
 />
@@ -97,7 +97,7 @@ To verify that Pixie is running in your environment you can check the <CloudLink
 # Check pods are up
 kubectl get pods -n pl \n
 # Check Pixie Platform and PEM status
-export PL_CLOUD_ADDR=@@
+export PX_CLOUD_ADDR=@@
 px get viziers
 px get pems
   `}

--- a/content/en/02-installing-pixie/04-install-schemes/03-helm.md
+++ b/content/en/02-installing-pixie/04-install-schemes/03-helm.md
@@ -21,9 +21,12 @@ Install the Pixie CLI following the directions [here](/installing-pixie/install-
 
 Check if your K8s cluster meets Pixie's [requirements](/installing-pixie/requirements) by running:
 
-```bash
+<TemplatedCodeBlock
+  code={`
+export PL_CLOUD_ADDR=@@
 px deploy --check_only
-```
+  `}
+/>
 
 If your cluster fails any checks, you may still proceed with installation, but it is unlikely that Pixie will work on your cluster.
 
@@ -47,25 +50,22 @@ Deploy Pixie in your target cluster by running:
   Please refer to <a href="/reference/admin/environment-configs">Environment-Specific Configurations</a> for other configurations that should be set for your specific Kubernetes environment.
 </Alert>
 
-```bash
+<TemplatedCodeBlock
+  code={`
 # Add the Pixie operator chart.
-helm repo add pixie-operator https://artifacts.px.dev/helm_charts/operator
-
+helm repo add pixie-operator https://artifacts.px.dev/helm_charts/operator \n
 # Get latest information about Pixie chart.
-helm repo update
-
+helm repo update \n
 # Install the Pixie chart (No OLM present on cluster).
-helm install pixie pixie-operator/pixie-operator-chart --set cloudAddr=<getcosmic.ai:443 or withpixie.ai:443> --set deployKey=<deploy-key-goes-here> --set clusterName=<cluster-name> --namespace pl --create-namespace
-
+helm install pixie pixie-operator/pixie-operator-chart --set cloudAddr=@@ --set deployKey=<deploy-key-goes-here> --set clusterName=<cluster-name> --namespace pl --create-namespace \n
 # Install the Pixie chart (OLM already exists on cluster).
-helm install pixie pixie-operator/pixie-operator-chart --set cloudAddr=<getcosmic.ai:443 or withpixie.ai:443> --set deployKey=<deploy-key-goes-here> --set clusterName=<cluster-name> --namespace pl --create-namespace --set deployOLM=false
-
+helm install pixie pixie-operator/pixie-operator-chart --set cloudAddr=@@ --set deployKey=<deploy-key-goes-here> --set clusterName=<cluster-name> --namespace pl --create-namespace --set deployOLM=false \n
 # Install the Pixie chart (Self-hosting Pixie Cloud)
-helm install pixie pixie-operator/pixie-operator-chart --set deployKey=<deploy-key-goes-here> --set clusterName=<cluster-name> --namespace pl --create-namespace --set devCloudNamespace=plc
-
+helm install pixie pixie-operator/pixie-operator-chart --set deployKey=<deploy-key-goes-here> --set clusterName=<cluster-name> --namespace pl --create-namespace --set devCloudNamespace=plc \n
 # Install Pixie with a memory limit for the PEM pods (per node). 2Gi is the default, 1Gi is the minimum recommended.
-helm install pixie pixie-operator/pixie-operator-chart --set cloudAddr=<getcosmic.ai:443 or withpixie.ai:443> --set deployKey=<deploy-key-goes-here> --set clusterName=<cluster-name> --namespace pl --create-namespace --set deployOLM=false --set pemMemoryLimit=1Gi
-```
+helm install pixie pixie-operator/pixie-operator-chart --set cloudAddr=@@ --set deployKey=<deploy-key-goes-here> --set clusterName=<cluster-name> --namespace pl --create-namespace --set deployOLM=false --set pemMemoryLimit=1Gi
+  `}
+/>
 
 Pixie will deploy pods to the `pl`, `px-operator`, and `olm`(if deploying the OLM) namespaces.
 
@@ -92,13 +92,13 @@ helm install pixie pixie-vizier/vizier-chart --set deployKey=<deploy-key-goes-he
 
 To verify that Pixie is running in your environment you can check the <CloudLink url="/admin">admin page</CloudLink> or run:
 
-```bash
+<TemplatedCodeBlock
+  code={`
 # Check pods are up
-kubectl get pods -n pl
-
-# Check Pixie Platform status
+kubectl get pods -n pl \n
+# Check Pixie Platform and PEM status
+export PL_CLOUD_ADDR=@@
 px get viziers
-
-# Check PEM stats
 px get pems
-```
+  `}
+/>

--- a/content/en/02-installing-pixie/04-install-schemes/03-helm.md
+++ b/content/en/02-installing-pixie/04-install-schemes/03-helm.md
@@ -23,7 +23,7 @@ Check if your K8s cluster meets Pixie's [requirements](/installing-pixie/require
 
 <TemplatedCodeBlock
   code={`
-export PX_CLOUD_ADDR=@@
+export PX_CLOUD_ADDR=@PLACEHOLDER@
 px deploy --check_only
   `}
 />
@@ -57,13 +57,13 @@ helm repo add pixie-operator https://artifacts.px.dev/helm_charts/operator \n
 # Get latest information about Pixie chart.
 helm repo update \n
 # Install the Pixie chart (No OLM present on cluster).
-helm install pixie pixie-operator/pixie-operator-chart --set cloudAddr=@@ --set deployKey=<deploy-key-goes-here> --set clusterName=<cluster-name> --namespace pl --create-namespace \n
+helm install pixie pixie-operator/pixie-operator-chart --set cloudAddr=@PLACEHOLDER@ --set deployKey=<deploy-key-goes-here> --set clusterName=<cluster-name> --namespace pl --create-namespace \n
 # Install the Pixie chart (OLM already exists on cluster).
-helm install pixie pixie-operator/pixie-operator-chart --set cloudAddr=@@ --set deployKey=<deploy-key-goes-here> --set clusterName=<cluster-name> --namespace pl --create-namespace --set deployOLM=false \n
+helm install pixie pixie-operator/pixie-operator-chart --set cloudAddr=@PLACEHOLDER@ --set deployKey=<deploy-key-goes-here> --set clusterName=<cluster-name> --namespace pl --create-namespace --set deployOLM=false \n
 # Install the Pixie chart (Self-hosting Pixie Cloud)
 helm install pixie pixie-operator/pixie-operator-chart --set deployKey=<deploy-key-goes-here> --set clusterName=<cluster-name> --namespace pl --create-namespace --set devCloudNamespace=plc \n
 # Install Pixie with a memory limit for the PEM pods (per node). 2Gi is the default, 1Gi is the minimum recommended.
-helm install pixie pixie-operator/pixie-operator-chart --set cloudAddr=@@ --set deployKey=<deploy-key-goes-here> --set clusterName=<cluster-name> --namespace pl --create-namespace --set deployOLM=false --set pemMemoryLimit=1Gi
+helm install pixie pixie-operator/pixie-operator-chart --set cloudAddr=@PLACEHOLDER@ --set deployKey=<deploy-key-goes-here> --set clusterName=<cluster-name> --namespace pl --create-namespace --set deployOLM=false --set pemMemoryLimit=1Gi
   `}
 />
 
@@ -97,7 +97,7 @@ To verify that Pixie is running in your environment you can check the <CloudLink
 # Check pods are up
 kubectl get pods -n pl \n
 # Check Pixie Platform and PEM status
-export PX_CLOUD_ADDR=@@
+export PX_CLOUD_ADDR=@PLACEHOLDER@
 px get viziers
 px get pems
   `}

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -31,10 +31,12 @@ const availableClouds = [
   {
     name: 'New Relic Cloud',
     baseUrl: 'https://work.withpixie.ai',
+    cloudAddr: 'withpixie.ai',
   },
   {
     name: 'Cosmic Cloud',
     baseUrl: 'https://work.getcosmic.ai',
+    cloudAddr: 'getcosmic.ai',
   },
 ];
 

--- a/src/components/cloudLinkProvider.tsx
+++ b/src/components/cloudLinkProvider.tsx
@@ -21,6 +21,7 @@ import * as React from 'react';
 const initialCloud = {
   name: 'New Relic Cloud',
   baseUrl: 'https://work.withpixe.ai',
+  cloudAddr: 'withpixie.ai',
 };
 
 export const CloudLinkContext = React.createContext(

--- a/src/components/mdxComponents/baseComponents.tsx
+++ b/src/components/mdxComponents/baseComponents.tsx
@@ -32,7 +32,7 @@ import AnchorTag from './anchor';
 import CodeRenderer from './codeRenderer';
 import ListItem from './listItem';
 import HLink from './h-link';
-import CloudLink from './cloud-link';
+import { CloudLink, CliDeployInstructions } from './cloud-link';
 import PoiTooltip from '../poi-tooltip/poi-tooltip';
 
 const getChildren = (props) => props.children;
@@ -92,4 +92,5 @@ export default {
   Alert,
   PoiTooltip,
   CloudLink: (props: any) => <CloudLink {...props} />,
+  CliDeployInstructions: (props: any) => <CliDeployInstructions {...props} />,
 };

--- a/src/components/mdxComponents/baseComponents.tsx
+++ b/src/components/mdxComponents/baseComponents.tsx
@@ -32,7 +32,7 @@ import AnchorTag from './anchor';
 import CodeRenderer from './codeRenderer';
 import ListItem from './listItem';
 import HLink from './h-link';
-import { CloudLink, CliDeployInstructions } from './cloud-link';
+import { CloudLink, TemplatedCodeBlock } from './cloud-link';
 import PoiTooltip from '../poi-tooltip/poi-tooltip';
 
 const getChildren = (props) => props.children;
@@ -92,5 +92,5 @@ export default {
   Alert,
   PoiTooltip,
   CloudLink: (props: any) => <CloudLink {...props} />,
-  CliDeployInstructions: (props: any) => <CliDeployInstructions {...props} />,
+  TemplatedCodeBlock: (props: any) => <TemplatedCodeBlock {...props} />,
 };

--- a/src/components/mdxComponents/cloud-link.tsx
+++ b/src/components/mdxComponents/cloud-link.tsx
@@ -36,11 +36,9 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
 }));
 
-interface Props {
-  children: string;
-}
+interface Props { }
 
-export const CliDeployInstructions: React.FC<Props> = ({ children }) => {
+export const CliDeployInstructions: React.FC<Props> = () => {
   const codeBlock = `
 # List Pixie deployment options.
 px deploy --help
@@ -62,8 +60,9 @@ px deploy --pem_memory_limit=1Gi
     <CloudLinkContext.Consumer>
       {({ selectedCloud }) => (
         <CodeRenderer
-          code={codeBlock.replaceAll("@@", selectedCloud.cloudAddr)}
-          language='bash' />
+          code={codeBlock.replaceAll('@@', selectedCloud.cloudAddr)}
+          language='bash'
+        />
       )}
     </CloudLinkContext.Consumer>
   );

--- a/src/components/mdxComponents/cloud-link.tsx
+++ b/src/components/mdxComponents/cloud-link.tsx
@@ -36,31 +36,17 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
 }));
 
-interface Props { }
+interface Props {
+  code: string;
+}
 
-export const CliDeployInstructions: React.FC<Props> = () => {
-  const codeBlock = `
-# List Pixie deployment options.
-px deploy --help
-
-# Deploy the Pixie Platform in your K8s cluster (No OLM present on cluster).
-export PL_CLOUD_ADDR=@@
-px deploy
-
-# Deploy the Pixie Platform in your K8s cluster (OLM already exists on cluster).
-export PL_CLOUD_ADDR=@@
-px deploy --deploy_olm=false
-
-# Deploy Pixie with a specific memory limit (2Gi is the default, 1Gi is the minimum recommended)
-export PL_CLOUD_ADDR=@@
-px deploy --pem_memory_limit=1Gi
-
-  `;
+// eslint-disable-next-line arrow-body-style
+export const TemplatedCodeBlock: React.FC<Props> = ({ code }) => {
   return (
     <CloudLinkContext.Consumer>
       {({ selectedCloud }) => (
         <CodeRenderer
-          code={codeBlock.replaceAll('@@', selectedCloud.cloudAddr)}
+          code={code.replaceAll('@@', selectedCloud.cloudAddr)}
           language='bash'
         />
       )}

--- a/src/components/mdxComponents/cloud-link.tsx
+++ b/src/components/mdxComponents/cloud-link.tsx
@@ -20,6 +20,7 @@ import * as React from 'react';
 import path from 'path';
 import { makeStyles } from '@material-ui/core/styles';
 import { CloudLinkContext } from '../cloudLinkProvider';
+import CodeRenderer from './codeRenderer';
 
 const useStyles = makeStyles((theme: Theme) => ({
   link: {
@@ -37,10 +38,43 @@ const useStyles = makeStyles((theme: Theme) => ({
 
 interface Props {
   children: string;
+}
+
+export const CliDeployInstructions: React.FC<Props> = ({ children }) => {
+  const codeBlock = `
+# List Pixie deployment options.
+px deploy --help
+
+# Deploy the Pixie Platform in your K8s cluster (No OLM present on cluster).
+export PL_CLOUD_ADDR=@@
+px deploy
+
+# Deploy the Pixie Platform in your K8s cluster (OLM already exists on cluster).
+export PL_CLOUD_ADDR=@@
+px deploy --deploy_olm=false
+
+# Deploy Pixie with a specific memory limit (2Gi is the default, 1Gi is the minimum recommended)
+export PL_CLOUD_ADDR=@@
+px deploy --pem_memory_limit=1Gi
+
+  `;
+  return (
+    <CloudLinkContext.Consumer>
+      {({ selectedCloud }) => (
+        <CodeRenderer
+          code={codeBlock.replaceAll("@@", selectedCloud.cloudAddr)}
+          language='bash' />
+      )}
+    </CloudLinkContext.Consumer>
+  );
+};
+
+interface CloudLinkProps {
+  children: string;
   url: string;
 }
 
-const CloudLink: React.FC<Props> = ({ children, url }) => {
+export const CloudLink: React.FC<CloudLinkProps> = ({ children, url }) => {
   const classes = useStyles();
   return (
     <CloudLinkContext.Consumer>
@@ -52,4 +86,3 @@ const CloudLink: React.FC<Props> = ({ children, url }) => {
     </CloudLinkContext.Consumer>
   );
 };
-export default CloudLink;

--- a/src/components/mdxComponents/cloud-link.tsx
+++ b/src/components/mdxComponents/cloud-link.tsx
@@ -46,7 +46,7 @@ export const TemplatedCodeBlock: React.FC<Props> = ({ code }) => {
     <CloudLinkContext.Consumer>
       {({ selectedCloud }) => (
         <CodeRenderer
-          code={code.replaceAll('@@', selectedCloud.cloudAddr)}
+          code={code.replaceAll('@PLACEHOLDER@', selectedCloud.cloudAddr)}
           language='bash'
         />
       )}


### PR DESCRIPTION
Summary: Update install scheme pages to reflect selected Cloud URL

This updates the CLI, Helm and YAML install scheme pages so that the instructions are copy and paste-able. See the screenshots below for the before and after.

Before:
![Screen Shot 2024-07-11 at 11 49 27 AM](https://github.com/pixie-io/docs.px.dev/assets/5855593/d09329d6-863c-49d5-ad76-b3e7e77512df)

After:

![Screen Shot 2024-07-11 at 2 33 27 PM](https://github.com/user-attachments/assets/5c8a06d5-37da-412c-8176-ecba13ca4dae)
![Screen Shot 2024-07-11 at 2 33 23 PM](https://github.com/user-attachments/assets/122eefac-6264-43f7-81ea-6072448607f9)
