### PR TITLE
Use cookies to remember previously selected Cloud

### DIFF
--- a/src/components/cloudLinkProvider.tsx
+++ b/src/components/cloudLinkProvider.tsx
@@ -17,11 +17,22 @@
  */
 
 import * as React from 'react';
+import Cookies from 'js-cookie';
 
-const initialCloud = {
-  name: 'New Relic Cloud',
-  baseUrl: 'https://work.withpixe.ai',
-};
+const availableClouds = [
+  {
+    name: 'New Relic Cloud',
+    baseUrl: 'https://work.withpixie.ai',
+    cloudAddr: 'withpixie.ai',
+  },
+  {
+    name: 'Cosmic Cloud',
+    baseUrl: 'https://work.getcosmic.ai',
+    cloudAddr: 'getcosmic.ai',
+  },
+];
+
+const initialCloud = availableClouds[0];
 
 export const CloudLinkContext = React.createContext(
   {
@@ -30,8 +41,29 @@ export const CloudLinkContext = React.createContext(
     setSelectedCloud: (cloud) => { },
   },
 );
+const getDefaultOrSelectedCloud = () => {
+  if (!Cookies.get('consent')) {
+    return initialCloud;
+  }
+  const selectedCloud = Cookies.get('selected-cloud');
+  if (selectedCloud) {
+    return JSON.parse(selectedCloud);
+  }
+  return initialCloud;
+};
 export default function CloudLinkProvider({ children }) {
-  const [selectedCloud, setSelectedCloud] = React.useState(initialCloud);
+  const isBrowser = typeof window !== 'undefined';
+  const [
+    selectedCloud,
+    setSelectedCloudState,
+  ] = React.useState(isBrowser ? getDefaultOrSelectedCloud() : initialCloud);
+  const setSelectedCloud = (cloud) => {
+    setSelectedCloudState(cloud);
+    // If the user has not consented to cookies, do not set a default cloud.
+    if (Cookies.get('consent')) {
+      Cookies.set('selected-cloud', cloud);
+    }
+  };
   return (
     <CloudLinkContext.Provider
       value={{


### PR DESCRIPTION
Summary: Use cookies to remember previously selected Cloud

If a user has consented to our use of cookies, it would be helpful for the docs site to remember which cloud they last selected.

Test plan:
- [x] Verified that the selected cloud is not stored unless cookies have been consented to
- [x] Verified that hard refreshing the page (after cookie consent) remembers the previously selected cloud 