### PR TITLE
Alphabetize Pixie clouds to match CNCF guidelines

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -29,14 +29,14 @@ const languages = require('./available-languages');
 
 const availableClouds = [
   {
-    name: 'New Relic Cloud',
-    baseUrl: 'https://work.withpixie.ai',
-    cloudAddr: 'withpixie.ai',
-  },
-  {
     name: 'Cosmic Cloud',
     baseUrl: 'https://work.getcosmic.ai',
     cloudAddr: 'getcosmic.ai',
+  },
+  {
+    name: 'New Relic Cloud',
+    baseUrl: 'https://work.withpixie.ai',
+    cloudAddr: 'withpixie.ai',
   },
 ];
 

--- a/src/components/cloudLinkProvider.tsx
+++ b/src/components/cloudLinkProvider.tsx
@@ -18,11 +18,20 @@
 
 import * as React from 'react';
 
-const initialCloud = {
-  name: 'New Relic Cloud',
-  baseUrl: 'https://work.withpixe.ai',
-  cloudAddr: 'withpixie.ai',
-};
+const availableClouds = [
+  {
+    name: 'Cosmic Cloud',
+    baseUrl: 'https://work.getcosmic.ai',
+    cloudAddr: 'getcosmic.ai',
+  },
+  {
+    name: 'New Relic Cloud',
+    baseUrl: 'https://work.withpixie.ai',
+    cloudAddr: 'withpixie.ai',
+  },
+];
+
+const initialCloud = availableClouds[0];
 
 export const CloudLinkContext = React.createContext(
   {


### PR DESCRIPTION
Summary: Alphabetize Pixie clouds to match CNCF guidelines

This ensures the pixie cloud offerings match the CNCF requirements documented [here](https://github.com/cncf/foundation/blob/42bc2197cce2f58b31eae5f5067f0fd04ab73482/website-guidelines.md).

> There should be no links or forms for capturing enterprise support leads. Instead, it is fine to have an enterprise support, commercial partners or similar page. Companies must be listed on that page in alphabetical order, or the order can be changed randomly on each page load.