### PR TITLE
Add MongoDB to the supported protocols list

### DIFF
--- a/content/en/01-about-pixie/02-data-sources.md
+++ b/content/en/01-about-pixie/02-data-sources.md
@@ -43,6 +43,7 @@ Pixie automatically traces the following protocols:
 | Redis         | Supported           |                                |
 | Kafka         | Supported           |                                |
 | AMQP          | Supported           |                                |
+| MongoDB       | Supported           |                                |
 
 Additional protocols are under development.
 


### PR DESCRIPTION
MongoDB has been supported for some time, but we forgot to add this to the supported protocols list.