### PR TITLE
Fix Openshift SecurityContextConstraints based on Vizier changes

### DIFF
--- a/content/en/05-reference/01-admin/04-environment-configs.md
+++ b/content/en/05-reference/01-admin/04-environment-configs.md
@@ -35,6 +35,8 @@ allowHostPID: true
 allowHostIPC: false
 allowHostPorts: false
 readOnlyRootFilesystem: false
+seccompProfiles:
+- runtime/default
 allowedCapabilities:
 - SYS_ADMIN
 - SYS_PTRACE
@@ -46,6 +48,10 @@ seLinuxContext:
  type: RunAsAny
 users:
 - system:serviceaccount:pl:default
+- system:serviceaccount:pl:query-broker-service-account
+- system:serviceaccount:pl:pl-cert-provisioner-service-account
+- system:serviceaccount:pl:cloud-conn-service-account
+
 ```
 
 Note: Make sure to set the namespace on the serviceAccount to the namespace you deployed Pixie to.


### PR DESCRIPTION
Deploying Pixie on Openshift fails when using the currently documented SecurityContextConstraints manifest. This updates the docs to a version of the SCC that works.


### Testing done
- Verified Pixie installs properly on openshift with `px deploy --olm_namespace openshift-operator-lifecycle-manager  --deploy_olm=false` and this version of the SCC

![openshift](https://github.com/user-attachments/assets/0f967878-857d-4b3c-a597-f17693757fe0)
