### PR TITLE
Add missing service accounts and etcd metadata capability to OpenShift SCC

### DIFF
--- a/content/en/05-reference/01-admin/04-environment-configs.md
+++ b/content/en/05-reference/01-admin/04-environment-configs.md
@@ -40,6 +40,7 @@ seccompProfiles:
 allowedCapabilities:
 - SYS_ADMIN
 - SYS_PTRACE
+- NET_RAW
 allowHostNetwork: true
 allowHostDirVolumePlugin: true
 runAsUser:

--- a/content/en/05-reference/01-admin/04-environment-configs.md
+++ b/content/en/05-reference/01-admin/04-environment-configs.md
@@ -48,9 +48,11 @@ seLinuxContext:
  type: RunAsAny
 users:
 - system:serviceaccount:pl:default
-- system:serviceaccount:pl:query-broker-service-account
-- system:serviceaccount:pl:pl-cert-provisioner-service-account
 - system:serviceaccount:pl:cloud-conn-service-account
+- system:serviceaccount:pl:metadata-service-account
+- system:serviceaccount:pl:pl-cert-provisioner-service-account
+- system:serviceaccount:pl:pl-updater-service-account
+- system:serviceaccount:pl:query-broker-service-account
 
 ```
 


### PR DESCRIPTION
Summary: Add missing service accounts and etcd metadata capability to OpenShift SCC

Someone from the community had trouble deploying the non-operator version of Pixie on Openshift. The `NET_RAW` capability is needed in order to have the etcd metadata store work properly. I also realized that these service accounts were missing from the SCC. I haven't seen a case where it has prevented Pixie from working, but I think it's best to include them to avoid future issues.